### PR TITLE
Fix command complete return parameters decoding

### DIFF
--- a/lib/harald/hci/commands/command.ex
+++ b/lib/harald/hci/commands/command.ex
@@ -14,5 +14,6 @@ defmodule Harald.HCI.Commands.Command do
 
   @callback encode(Command.t()) :: {:ok, binary()} | {:error, any()}
   @callback decode(binary()) :: {:ok, Command.t()} | {:error, any()}
+  @callback decode_return_parameters(binary()) :: {:ok, map()} | {:error, any()}
   @callback ocf() :: {:ok, Commands.ocf()} | {:error, any()}
 end

--- a/lib/harald/hci/commands/controller_and_baseband/read_local_name.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/read_local_name.ex
@@ -1,4 +1,8 @@
 defmodule Harald.HCI.Commands.ControllerAndBaseband.ReadLocalName do
+  @moduledoc """
+  Reference: version 5.2, Vol 4, Part E, 7.3.12.
+  """
+
   alias Harald.HCI.Commands.Command
 
   @behaviour Command
@@ -8,6 +12,11 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.ReadLocalName do
 
   @impl Command
   def decode(<<>>), do: {:ok, %{}}
+
+  @impl Command
+  def decode_return_parameters(<<status, local_name::binary-size(248)>>) do
+    {:ok, %{status: status, local_name: local_name}}
+  end
 
   @impl Command
   def ocf(), do: 0x14

--- a/lib/harald/hci/commands/controller_and_baseband/write_local_name.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/write_local_name.ex
@@ -1,4 +1,8 @@
 defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteLocalName do
+  @moduledoc """
+  Reference: version 5.2, Vol 4, Part E, 7.3.11.
+  """
+
   alias Harald.HCI.Commands.Command
 
   @behaviour Command
@@ -21,6 +25,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteLocalName do
   def decode(<<local_name::binary>>) when byte_size(local_name) <= @max_local_name_byte_size do
     {:ok, %{read_local_name: local_name}}
   end
+
+  @impl Command
+  def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
   def ocf(), do: 0x13

--- a/lib/harald/hci/commands/controller_and_baseband/write_pin_type.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/write_pin_type.ex
@@ -1,4 +1,8 @@
 defmodule Harald.HCI.Commands.ControllerAndBaseband.WritePinType do
+  @moduledoc """
+  Reference: version 5.2, Vol 4, Part E, 7.3.6.
+  """
+
   alias Harald.HCI.Commands.Command
 
   @behaviour Command
@@ -10,6 +14,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WritePinType do
   @impl Command
   def decode(<<0>>), do: {:ok, %{pin_type: :variable}}
   def decode(<<1>>), do: {:ok, %{pin_type: :fixed}}
+
+  @impl Command
+  def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
   def ocf(), do: 0xA

--- a/lib/harald/hci/commands/controller_and_baseband/write_simple_pairing_mode.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/write_simple_pairing_mode.ex
@@ -1,4 +1,8 @@
 defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteSimplePairingMode do
+  @moduledoc """
+  Reference: version 5.2, Vol 4, Part E, 7.3.59.
+  """
+
   alias Harald.HCI.Commands.Command
 
   @behaviour Command
@@ -10,6 +14,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteSimplePairingMode do
   @impl Command
   def decode(<<1>>), do: {:ok, %{simple_pairing_mode: true}}
   def decode(<<0>>), do: {:ok, %{simple_pairing_mode: false}}
+
+  @impl Command
+  def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
   def ocf(), do: 0x56

--- a/lib/harald/hci/commands/le_controller/le_set_advertising_data.ex
+++ b/lib/harald/hci/commands/le_controller/le_set_advertising_data.ex
@@ -1,4 +1,8 @@
 defmodule Harald.HCI.Commands.LEController.LESetAdvertisingData do
+  @moduledoc """
+  Reference: version 5.2, Vol 4, Part E, 7.8.7.
+  """
+
   alias Harald.HCI.Commands.Command
 
   @behaviour Command
@@ -19,6 +23,9 @@ defmodule Harald.HCI.Commands.LEController.LESetAdvertisingData do
   end
 
   def decode(_), do: {:error, :decode}
+
+  @impl Command
+  def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
   def ocf(), do: 0x08

--- a/lib/harald/hci/commands/le_controller/le_set_advertising_enable.ex
+++ b/lib/harald/hci/commands/le_controller/le_set_advertising_enable.ex
@@ -1,4 +1,8 @@
 defmodule Harald.HCI.Commands.LEController.LESetAdvertisingEnable do
+  @moduledoc """
+  Reference: version 5.2, Vol 4, Part E, 7.8.9.
+  """
+
   alias Harald.HCI.Commands.Command
 
   @behaviour Command
@@ -10,6 +14,9 @@ defmodule Harald.HCI.Commands.LEController.LESetAdvertisingEnable do
   @impl Command
   def decode(<<0>>), do: {:ok, %{advertising_enable: false}}
   def decode(<<1>>), do: {:ok, %{advertising_enable: true}}
+
+  @impl Command
+  def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
   def ocf(), do: 0x0A

--- a/lib/harald/hci/commands/le_controller/le_set_advertising_parameters.ex
+++ b/lib/harald/hci/commands/le_controller/le_set_advertising_parameters.ex
@@ -1,4 +1,8 @@
 defmodule Harald.HCI.Commands.LEController.LESetAdvertisingParameters do
+  @moduledoc """
+  Reference: version 5.2, Vol 4, Part E, 7.8.5.
+  """
+
   alias Harald.HCI.Commands.Command
 
   @behaviour Command
@@ -14,6 +18,8 @@ defmodule Harald.HCI.Commands.LEController.LESetAdvertisingParameters do
         advertising_channel_map: advertising_channel_map,
         advertising_filter_policy: advertising_filter_policy
       }) do
+    peer_address = String.pad_trailing(peer_address, 6, <<0>>)
+
     bin =
       <<advertising_interval_min::little-size(16), advertising_interval_max::little-size(16),
         advertising_type, own_address_type, peer_address_type,
@@ -44,6 +50,9 @@ defmodule Harald.HCI.Commands.LEController.LESetAdvertisingParameters do
 
     {:ok, parameters}
   end
+
+  @impl Command
+  def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
   def ocf(), do: 0x06

--- a/lib/harald/hci/commands/le_controller/le_set_event_mask.ex
+++ b/lib/harald/hci/commands/le_controller/le_set_event_mask.ex
@@ -1,4 +1,8 @@
 defmodule Harald.HCI.Commands.LEController.LESetEventMask do
+  @moduledoc """
+  Reference: version 5.2, Vol 4, Part E, 7.8.1.
+  """
+
   alias Harald.HCI.Commands.Command
 
   @behaviour Command
@@ -180,6 +184,9 @@ defmodule Harald.HCI.Commands.LEController.LESetEventMask do
 
     {:ok, parameters}
   end
+
+  @impl Command
+  def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
   def ocf(), do: 0x01

--- a/lib/harald/hci/events/command_complete.ex
+++ b/lib/harald/hci/events/command_complete.ex
@@ -22,7 +22,7 @@ defmodule Harald.HCI.Events.CommandComplete do
                 |> Map.take([:ocf, :ogf])
                 |> Map.merge(%{ocf_module: ocf_module, ogf_module: ogf_module})
 
-              return_parameters = ocf_module.decode(return_parameters)
+              return_parameters = ocf_module.decode_return_parameters(return_parameters)
               {command_op_code, return_parameters}
 
             {:error, :not_implemented} ->

--- a/test/harald/hci/controller_and_baseband/read_local_name_test.exs
+++ b/test/harald/hci/controller_and_baseband/read_local_name_test.exs
@@ -27,4 +27,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.ReadLocalNameTest do
     assert expected_size == byte_size(actual_bin)
     assert expected_bin == actual_bin
   end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    local_name = "bob"
+    padded_local_name = String.pad_trailing(local_name, 248, <<0>>)
+    return_parameters = <<status, padded_local_name::binary>>
+    expected_return_parameters = %{status: status, local_name: padded_local_name}
+
+    assert {:ok, expected_return_parameters} ==
+             ReadLocalName.decode_return_parameters(return_parameters)
+  end
 end

--- a/test/harald/hci/controller_and_baseband/write_local_name_test.exs
+++ b/test/harald/hci/controller_and_baseband/write_local_name_test.exs
@@ -32,4 +32,13 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteLocalNameTest do
     assert expected_size == byte_size(actual_bin)
     assert expected_bin == actual_bin
   end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             WriteLocalName.decode_return_parameters(return_parameters)
+  end
 end

--- a/test/harald/hci/controller_and_baseband/write_pin_type_test.exs
+++ b/test/harald/hci/controller_and_baseband/write_pin_type_test.exs
@@ -31,4 +31,13 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WritePinTypeTest do
     assert expected_size == byte_size(actual_bin)
     assert expected_bin == actual_bin
   end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             WritePinType.decode_return_parameters(return_parameters)
+  end
 end

--- a/test/harald/hci/controller_and_baseband/write_simple_pairing_mode_test.exs
+++ b/test/harald/hci/controller_and_baseband/write_simple_pairing_mode_test.exs
@@ -32,4 +32,13 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteSimplePairingModeTest d
     assert expected_size == byte_size(actual_bin)
     assert expected_bin == actual_bin
   end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             WriteSimplePairingMode.decode_return_parameters(return_parameters)
+  end
 end

--- a/test/harald/hci/le_controller/le_set_advertising_data_test.exs
+++ b/test/harald/hci/le_controller/le_set_advertising_data_test.exs
@@ -42,4 +42,13 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.LESetAdvertisingDataTest do
     assert expected_size == byte_size(actual_bin)
     assert expected_bin == actual_bin
   end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             LESetAdvertisingData.decode_return_parameters(return_parameters)
+  end
 end

--- a/test/harald/hci/le_controller/le_set_advertising_enable_test.exs
+++ b/test/harald/hci/le_controller/le_set_advertising_enable_test.exs
@@ -38,4 +38,13 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.LESetAdvertisingEnableTest d
     assert expected_size == byte_size(actual_bin)
     assert expected_bin == actual_bin
   end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             LESetAdvertisingEnable.decode_return_parameters(return_parameters)
+  end
 end

--- a/test/harald/hci/le_controller/le_set_advertising_parameters_test.exs
+++ b/test/harald/hci/le_controller/le_set_advertising_parameters_test.exs
@@ -79,4 +79,13 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.LESetAdvertisingParametersTe
     assert expected_size == byte_size(actual_bin)
     assert expected_bin == actual_bin
   end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             LESetAdvertisingParameters.decode_return_parameters(return_parameters)
+  end
 end

--- a/test/harald/hci/le_controller/le_set_event_mask_test.exs
+++ b/test/harald/hci/le_controller/le_set_event_mask_test.exs
@@ -262,4 +262,13 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.LESetEventMaskTest do
     assert expected_size == byte_size(actual_bin)
     assert expected_bin == actual_bin
   end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             LESetEventMask.decode_return_parameters(return_parameters)
+  end
 end


### PR DESCRIPTION
- Add spec references to all commands.
- Add "decode_return_parameters" callback to "Command".
- Implement "decode_return_parameters" for all commands.
- Change "CommandComplete" to call "decode_return_parameters" instead of
  "decode" on the OCF module.
- Add tests for all commands for "decode_return_parameters".