### PR TITLE
Add ConnectionComplete and refactor events for LE

### DIFF
--- a/lib/harald/hci/commands/command.ex
+++ b/lib/harald/hci/commands/command.ex
@@ -15,5 +15,6 @@ defmodule Harald.HCI.Commands.Command do
   @callback encode(Command.t()) :: {:ok, binary()} | {:error, any()}
   @callback decode(binary()) :: {:ok, Command.t()} | {:error, any()}
   @callback decode_return_parameters(binary()) :: {:ok, map()} | {:error, any()}
+  @callback encode_return_parameters(map()) :: {:ok, binary()} | {:error, any()}
   @callback ocf() :: {:ok, Commands.ocf()} | {:error, any()}
 end

--- a/lib/harald/hci/commands/controller_and_baseband/read_local_name.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/read_local_name.ex
@@ -19,5 +19,10 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.ReadLocalName do
   end
 
   @impl Command
+  def encode_return_parameters(%{status: status, local_name: local_name}) do
+    {:ok, <<status, local_name::binary-size(248)>>}
+  end
+
+  @impl Command
   def ocf(), do: 0x14
 end

--- a/lib/harald/hci/commands/controller_and_baseband/set_event_mask.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/set_event_mask.ex
@@ -274,5 +274,8 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMask do
   def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
+  def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
+
+  @impl Command
   def ocf(), do: 0x01
 end

--- a/lib/harald/hci/commands/controller_and_baseband/write_local_name.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/write_local_name.ex
@@ -30,5 +30,8 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteLocalName do
   def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
+  def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
+
+  @impl Command
   def ocf(), do: 0x13
 end

--- a/lib/harald/hci/commands/controller_and_baseband/write_pin_type.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/write_pin_type.ex
@@ -19,5 +19,8 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WritePinType do
   def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
+  def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
+
+  @impl Command
   def ocf(), do: 0xA
 end

--- a/lib/harald/hci/commands/controller_and_baseband/write_simple_pairing_mode.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/write_simple_pairing_mode.ex
@@ -19,5 +19,8 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteSimplePairingMode do
   def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
+  def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
+
+  @impl Command
   def ocf(), do: 0x56
 end

--- a/lib/harald/hci/commands/le_controller/le_set_advertising_data.ex
+++ b/lib/harald/hci/commands/le_controller/le_set_advertising_data.ex
@@ -28,5 +28,8 @@ defmodule Harald.HCI.Commands.LEController.LESetAdvertisingData do
   def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
+  def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
+
+  @impl Command
   def ocf(), do: 0x08
 end

--- a/lib/harald/hci/commands/le_controller/le_set_advertising_enable.ex
+++ b/lib/harald/hci/commands/le_controller/le_set_advertising_enable.ex
@@ -19,5 +19,8 @@ defmodule Harald.HCI.Commands.LEController.LESetAdvertisingEnable do
   def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
+  def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
+
+  @impl Command
   def ocf(), do: 0x0A
 end

--- a/lib/harald/hci/commands/le_controller/le_set_advertising_parameters.ex
+++ b/lib/harald/hci/commands/le_controller/le_set_advertising_parameters.ex
@@ -55,5 +55,8 @@ defmodule Harald.HCI.Commands.LEController.LESetAdvertisingParameters do
   def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
+  def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
+
+  @impl Command
   def ocf(), do: 0x06
 end

--- a/lib/harald/hci/commands/le_controller/le_set_event_mask.ex
+++ b/lib/harald/hci/commands/le_controller/le_set_event_mask.ex
@@ -189,5 +189,8 @@ defmodule Harald.HCI.Commands.LEController.LESetEventMask do
   def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
+  def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
+
+  @impl Command
   def ocf(), do: 0x01
 end

--- a/lib/harald/hci/events.ex
+++ b/lib/harald/hci/events.ex
@@ -4,93 +4,43 @@ defmodule Harald.HCI.Events do
   """
 
   alias Harald.HCI.Events
-  alias Harald.HCI.{Events.Event, Events.CommandComplete}
-
+  alias Harald.HCI.Events.Event
+  alias Harald.HCI.Events.{CommandComplete, LEMeta}
   @type event_code() :: non_neg_integer()
+
+  def encode(%Event{
+        code: _event_code,
+        module: event_module,
+        parameters: parameters
+      }) do
+    event_module.encode(parameters)
+  end
 
   def decode(bin) when is_binary(bin) do
     case bin do
       <<event_code, _length, data::binary()>> ->
-        {:ok, event_code_module} = event_code_to_module(event_code)
-        {:ok, parameters} = event_code_module.decode(data)
-        Events.new(event_code_module, parameters)
+        {:ok, event_module} = event_code_to_module(event_code)
+        {:ok, parameters} = event_module.decode(data)
+        Events.new(event_module, parameters)
 
       <<>> ->
         :error
     end
   end
 
-  def event_code_to_module(0xE), do: {:ok, CommandComplete}
+  def event_code_to_module(0x0E), do: {:ok, CommandComplete}
+  def event_code_to_module(0x3E), do: {:ok, LEMeta}
   def event_code_to_module(_event_code), do: {:error, :not_implemented}
 
-  def new(event_code_module, parameters)
-      when is_atom(event_code_module) and (is_binary(parameters) or is_map(parameters)) do
+  def new(event_module, parameters)
+      when is_atom(event_module) and (is_binary(parameters) or is_map(parameters)) do
     event =
       struct(Event, %{
-        event_code: event_code_module,
+        code: event_module.event_code(),
+        module: event_module,
         parameters: parameters
       })
 
     {:ok, event}
   end
-
-  # alias Harald.HCI.Event.{InquiryComplete, LEMeta}
-  # alias Harald.Serializable
-
-  # @behaviour Serializable
-
-  # @event_modules [InquiryComplete, LEMeta]
-
-  # @typedoc """
-  # > Each event is assigned a 1-Octet event code used to uniquely identify different types of
-  # > events.
-
-  # Reference: Version 5.0, Vol 2, Part E, 5.4.4
-  # """
-  # @type event_code :: pos_integer()
-
-  # @type t :: struct()
-
-  # @type serialize_ret :: {:ok, binary()} | LEMeta.serialize_ret()
-
-  # @type deserialize_ret :: {:ok, t() | [t()]} | {:error, binary()}
-
-  # @doc """
-  # A list of modules representing implemented events.
-  # """
-  # def event_modules, do: @event_modules
-
-  # @doc """
-  # HCI packet indicator for HCI Event Packet.
-
-  # Reference: Version 5.0, Vol 5, Part A, 2
-  # """
-  # def indicator, do: 4
-
-  # @impl Serializable
-  # def serialize(event)
-
-  # Enum.each(@event_modules, fn module ->
-  #   def serialize(%unquote(module){} = event) do
-  #     {:ok, bin} = unquote(module).serialize(event)
-  #     {:ok, <<unquote(module).event_code(), byte_size(bin), bin::binary>>}
-  #   end
-  # end)
-
-  # def serialize(event), do: {:error, {:bad_event, event}}
-
-  # @impl Serializable
-  # def deserialize(binary)
-
-  # Enum.each(@event_modules, fn module ->
-  #   def deserialize(<<unquote(module.event_code()), length, event_parameters::binary>> = bin) do
-  #     if length == byte_size(event_parameters) do
-  #       unquote(module).deserialize(event_parameters)
-  #     else
-  #       {:error, bin}
-  #     end
-  #   end
-  # end)
-
-  # def deserialize(bin) when is_binary(bin), do: {:error, bin}
 end

--- a/lib/harald/hci/events/event.ex
+++ b/lib/harald/hci/events/event.ex
@@ -1,10 +1,12 @@
 defmodule Harald.HCI.Events.Event do
   @enforce_keys [
-    :event_code,
+    :code,
+    :module,
     :parameters
   ]
   defstruct [
-    :event_code,
+    :code,
+    :module,
     :parameters
   ]
 

--- a/lib/harald/hci/events/le_meta/connection_complete.ex
+++ b/lib/harald/hci/events/le_meta/connection_complete.ex
@@ -1,0 +1,61 @@
+defmodule Harald.HCI.Events.LEMeta.ConnectionComplete do
+  alias Harald.HCI.Events.LEMeta
+
+  @behaviour LEMeta
+
+  @impl LEMeta
+  def encode(%{
+        status: status,
+        connection_handle: connection_handle,
+        role: role,
+        peer_address_type: peer_address_type,
+        peer_address: peer_address,
+        connection_latency: connection_latency,
+        connection_interval: connection_interval,
+        supervision_timeout: supervision_timeout,
+        master_clock_accuracy: master_clock_accuracy
+      }) do
+    {:ok,
+     <<
+       status,
+       connection_handle::binary-little-size(2),
+       role,
+       peer_address_type,
+       peer_address::binary-little-size(6),
+       connection_interval::little-size(16),
+       connection_latency::little-size(16),
+       supervision_timeout::little-size(16),
+       master_clock_accuracy
+     >>}
+  end
+
+  @impl LEMeta
+  def decode(<<
+        status,
+        connection_handle::binary-little-size(2),
+        role,
+        peer_address_type,
+        peer_address::binary-little-size(6),
+        connection_interval::little-size(16),
+        connection_latency::little-size(16),
+        supervision_timeout::little-size(16),
+        master_clock_accuracy
+      >>) do
+    parameters = %{
+      status: status,
+      connection_handle: connection_handle,
+      role: role,
+      peer_address_type: peer_address_type,
+      peer_address: peer_address,
+      connection_latency: connection_latency,
+      connection_interval: connection_interval,
+      supervision_timeout: supervision_timeout,
+      master_clock_accuracy: master_clock_accuracy
+    }
+
+    {:ok, parameters}
+  end
+
+  @impl LEMeta
+  def sub_event_code(), do: 0x01
+end

--- a/test/harald/hci/commands/controller_and_baseband/read_local_name_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/read_local_name_test.exs
@@ -1,0 +1,53 @@
+defmodule Harald.HCI.Commands.ControllerAndBaseband.ReadLocalNameTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.{Commands, Commands.Command, Commands.ControllerAndBaseband}
+  alias Harald.HCI.Commands.ControllerAndBaseband.ReadLocalName
+
+  test "decode/1" do
+    expected_bin = <<1, 20, 12, 0>>
+
+    expected_command = %Command{
+      command_op_code: %{
+        ocf: 0x14,
+        ocf_module: ReadLocalName,
+        ogf: 0x3,
+        ogf_module: ControllerAndBaseband
+      },
+      parameters: %{}
+    }
+
+    assert {:ok, expected_command} == Commands.decode(expected_bin)
+  end
+
+  test "encode/1" do
+    expected_bin = <<1, 20, 12, 0>>
+    expected_size = byte_size(expected_bin)
+    params = %{}
+    assert {:ok, actual_bin} = Commands.encode(ControllerAndBaseband, ReadLocalName, params)
+    assert expected_size == byte_size(actual_bin)
+    assert expected_bin == actual_bin
+  end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    local_name = "bob"
+    padded_local_name = String.pad_trailing(local_name, 248, <<0>>)
+    return_parameters = <<status, padded_local_name::binary>>
+    expected_return_parameters = %{status: status, local_name: padded_local_name}
+
+    assert {:ok, expected_return_parameters} ==
+             ReadLocalName.decode_return_parameters(return_parameters)
+  end
+
+  test "encode_return_parameters/1" do
+    status = 1
+    local_name_size = 248
+    local_name = "bob"
+    padded_local_name = String.pad_trailing(local_name, local_name_size, <<0>>)
+    encoded_return_parameters = <<status, padded_local_name::binary-size(local_name_size)>>
+    decoded_return_parameters = %{local_name: padded_local_name, status: status}
+
+    assert {:ok, encoded_return_parameters} ==
+             ReadLocalName.encode_return_parameters(decoded_return_parameters)
+  end
+end

--- a/test/harald/hci/commands/controller_and_baseband/write_local_name_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/write_local_name_test.exs
@@ -1,0 +1,53 @@
+defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteLocalNameTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.{Commands, Commands.Command, Commands.ControllerAndBaseband}
+  alias Harald.HCI.Commands.ControllerAndBaseband.WriteLocalName
+
+  test "decode/1" do
+    name = "bob"
+    expected_name = String.pad_trailing(name, 248, <<0>>)
+    expected_bin = <<1, 19, 12, 248, expected_name::binary>>
+    local_name = String.pad_trailing(name, 248, <<0>>)
+
+    expected_command = %Command{
+      command_op_code: %{
+        ocf: 0x13,
+        ocf_module: WriteLocalName,
+        ogf: 0x3,
+        ogf_module: ControllerAndBaseband
+      },
+      parameters: %{read_local_name: local_name}
+    }
+
+    assert {:ok, expected_command} == Commands.decode(expected_bin)
+  end
+
+  test "encode/1" do
+    name = "bob"
+    expected_name = String.pad_trailing(name, 248, <<0>>)
+    expected_bin = <<1, 19, 12, 248, expected_name::binary>>
+    expected_size = byte_size(expected_bin)
+    params = %{local_name: "bob"}
+    assert {:ok, actual_bin} = Commands.encode(ControllerAndBaseband, WriteLocalName, params)
+    assert expected_size == byte_size(actual_bin)
+    assert expected_bin == actual_bin
+  end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             WriteLocalName.decode_return_parameters(return_parameters)
+  end
+
+  test "encode_return_parameters/1" do
+    status = 1
+    encoded_return_parameters = <<status>>
+    decoded_return_parameters = %{status: status}
+
+    assert {:ok, encoded_return_parameters} ==
+             WriteLocalName.encode_return_parameters(decoded_return_parameters)
+  end
+end

--- a/test/harald/hci/commands/controller_and_baseband/write_pin_type_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/write_pin_type_test.exs
@@ -1,0 +1,52 @@
+defmodule Harald.HCI.Commands.ControllerAndBaseband.WritePinTypeTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.{Commands, Commands.Command, Commands.ControllerAndBaseband}
+  alias Harald.HCI.Commands.ControllerAndBaseband.WritePinType
+
+  test "decode/1" do
+    pin_type = 0
+    expected_bin = <<1, 10, 12, 1, pin_type>>
+
+    expected_command = %Command{
+      command_op_code: %{
+        ocf: 0xA,
+        ocf_module: WritePinType,
+        ogf: 0x3,
+        ogf_module: ControllerAndBaseband
+      },
+      parameters: %{pin_type: :variable}
+    }
+
+    assert {:ok, expected_command} == Commands.decode(expected_bin)
+  end
+
+  test "encode/1" do
+    pin_type = 0
+    expected_bin = <<1, 10, 12, 1, pin_type>>
+    expected_size = byte_size(expected_bin)
+    params = %{pin_type: :variable}
+
+    assert {:ok, actual_bin} = Commands.encode(ControllerAndBaseband, WritePinType, params)
+
+    assert expected_size == byte_size(actual_bin)
+    assert expected_bin == actual_bin
+  end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             WritePinType.decode_return_parameters(return_parameters)
+  end
+
+  test "encode_return_parameters/1" do
+    status = 1
+    encoded_return_parameters = <<status>>
+    decoded_return_parameters = %{status: status}
+
+    assert {:ok, encoded_return_parameters} ==
+             WritePinType.encode_return_parameters(decoded_return_parameters)
+  end
+end

--- a/test/harald/hci/commands/controller_and_baseband/write_simple_pairing_mode_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/write_simple_pairing_mode_test.exs
@@ -1,0 +1,53 @@
+defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteSimplePairingModeTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.{Commands, Commands.Command, Commands.ControllerAndBaseband}
+  alias Harald.HCI.Commands.ControllerAndBaseband.WriteSimplePairingMode
+
+  test "decode/1" do
+    simple_pairing_mode = 1
+    expected_bin = <<1, 86, 12, 1, simple_pairing_mode>>
+
+    expected_command = %Command{
+      command_op_code: %{
+        ocf: 0x56,
+        ocf_module: WriteSimplePairingMode,
+        ogf: 0x3,
+        ogf_module: ControllerAndBaseband
+      },
+      parameters: %{simple_pairing_mode: true}
+    }
+
+    assert {:ok, expected_command} == Commands.decode(expected_bin)
+  end
+
+  test "encode/1" do
+    simple_pairing_mode = 1
+    expected_bin = <<1, 86, 12, 1, simple_pairing_mode>>
+    expected_size = byte_size(expected_bin)
+    params = %{simple_pairing_mode: true}
+
+    assert {:ok, actual_bin} =
+             Commands.encode(ControllerAndBaseband, WriteSimplePairingMode, params)
+
+    assert expected_size == byte_size(actual_bin)
+    assert expected_bin == actual_bin
+  end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             WriteSimplePairingMode.decode_return_parameters(return_parameters)
+  end
+
+  test "encode_return_parameters/1" do
+    status = 1
+    encoded_return_parameters = <<status>>
+    decoded_return_parameters = %{status: status}
+
+    assert {:ok, encoded_return_parameters} ==
+             WriteSimplePairingMode.encode_return_parameters(decoded_return_parameters)
+  end
+end

--- a/test/harald/hci/commands/le_controller/le_set_advertising_data_test.exs
+++ b/test/harald/hci/commands/le_controller/le_set_advertising_data_test.exs
@@ -1,0 +1,63 @@
+defmodule Harald.HCI.Commands.ControllerAndBaseband.LESetAdvertisingDataTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.Commands.{Command, LEController}
+  alias Harald.HCI.{Commands, Commands.LEController.LESetAdvertisingData}
+
+  test "decode/1" do
+    advertising_data = <<1, 3, 3, 7>>
+    advertising_data_length = byte_size(advertising_data)
+    length = advertising_data_length + 1
+    expected_bin = <<1, 8, 32, length, advertising_data_length, advertising_data::binary>>
+
+    expected_command = %Command{
+      command_op_code: %{
+        ocf: 0x08,
+        ocf_module: LESetAdvertisingData,
+        ogf: 0x08,
+        ogf_module: LEController
+      },
+      parameters: %{
+        advertising_data_length: advertising_data_length,
+        advertising_data: advertising_data
+      }
+    }
+
+    assert {:ok, expected_command} == Commands.decode(expected_bin)
+  end
+
+  test "encode/1" do
+    advertising_data = <<1, 3, 3, 7>>
+    advertising_data_length = byte_size(advertising_data)
+    length = advertising_data_length + 1
+    expected_bin = <<1, 8, 32, length, advertising_data_length, advertising_data::binary>>
+    expected_size = byte_size(expected_bin)
+
+    params = %{
+      advertising_data_length: advertising_data_length,
+      advertising_data: advertising_data
+    }
+
+    assert {:ok, actual_bin} = Commands.encode(LEController, LESetAdvertisingData, params)
+
+    assert expected_size == byte_size(actual_bin)
+    assert expected_bin == actual_bin
+  end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             LESetAdvertisingData.decode_return_parameters(return_parameters)
+  end
+
+  test "encode_return_parameters/1" do
+    status = 1
+    encoded_return_parameters = <<status>>
+    decoded_return_parameters = %{status: status}
+
+    assert {:ok, encoded_return_parameters} ==
+             LESetAdvertisingData.encode_return_parameters(decoded_return_parameters)
+  end
+end

--- a/test/harald/hci/commands/le_controller/le_set_advertising_enable_test.exs
+++ b/test/harald/hci/commands/le_controller/le_set_advertising_enable_test.exs
@@ -1,0 +1,59 @@
+defmodule Harald.HCI.Commands.ControllerAndBaseband.LESetAdvertisingEnableTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.Commands.{Command, LEController}
+  alias Harald.HCI.{Commands, Commands.LEController.LESetAdvertisingEnable}
+
+  test "decode/1" do
+    {advertising_enable_encoded, advertising_enable_decoded} = {1, true}
+    parameters = <<advertising_enable_encoded>>
+    parameters_length = byte_size(parameters)
+    expected_bin = <<1, 0x0A, 32, parameters_length, parameters::binary>>
+
+    expected_command = %Command{
+      command_op_code: %{
+        ocf: 0x0A,
+        ocf_module: LESetAdvertisingEnable,
+        ogf: 0x08,
+        ogf_module: LEController
+      },
+      parameters: %{
+        advertising_enable: advertising_enable_decoded
+      }
+    }
+
+    assert {:ok, expected_command} == Commands.decode(expected_bin)
+  end
+
+  test "encode/1" do
+    {advertising_enable_encoded, advertising_enable_decoded} = {1, true}
+    parameters = <<advertising_enable_encoded>>
+    parameters_length = byte_size(parameters)
+    expected_bin = <<1, 0x0A, 32, parameters_length, parameters::binary>>
+    expected_size = byte_size(expected_bin)
+
+    parameters = %{advertising_enable: advertising_enable_decoded}
+
+    assert {:ok, actual_bin} = Commands.encode(LEController, LESetAdvertisingEnable, parameters)
+
+    assert expected_size == byte_size(actual_bin)
+    assert expected_bin == actual_bin
+  end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             LESetAdvertisingEnable.decode_return_parameters(return_parameters)
+  end
+
+  test "encode_return_parameters/1" do
+    status = 1
+    encoded_return_parameters = <<status>>
+    decoded_return_parameters = %{status: status}
+
+    assert {:ok, encoded_return_parameters} ==
+             LESetAdvertisingEnable.encode_return_parameters(decoded_return_parameters)
+  end
+end

--- a/test/harald/hci/commands/le_controller/le_set_advertising_parameters_test.exs
+++ b/test/harald/hci/commands/le_controller/le_set_advertising_parameters_test.exs
@@ -1,0 +1,100 @@
+defmodule Harald.HCI.Commands.ControllerAndBaseband.LESetAdvertisingParametersTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.Commands.{Command, LEController}
+  alias Harald.HCI.{Commands, Commands.LEController.LESetAdvertisingParameters}
+
+  test "decode/1" do
+    advertising_interval_min = 0x800
+    advertising_interval_max = 0x800
+    advertising_type = 0x000
+    own_address_type = 0x000
+    peer_address_type = 0x000
+    peer_address = <<0, 0, 0, 0, 0, 0>>
+    advertising_channel_map = 0x007
+    advertising_filter_policy = 0x000
+
+    parameters =
+      <<advertising_interval_min::little-size(16), advertising_interval_max::little-size(16),
+        advertising_type, own_address_type, peer_address_type,
+        peer_address::binary-little-size(6), advertising_channel_map, advertising_filter_policy>>
+
+    parameters_length = byte_size(parameters)
+    expected_bin = <<1, 6, 32, parameters_length, parameters::binary>>
+
+    expected_command = %Command{
+      command_op_code: %{
+        ocf: 0x06,
+        ocf_module: LESetAdvertisingParameters,
+        ogf: 0x08,
+        ogf_module: LEController
+      },
+      parameters: %{
+        advertising_interval_min: advertising_interval_min,
+        advertising_interval_max: advertising_interval_max,
+        advertising_type: advertising_type,
+        own_address_type: own_address_type,
+        peer_address_type: peer_address_type,
+        peer_address: peer_address,
+        advertising_channel_map: advertising_channel_map,
+        advertising_filter_policy: advertising_filter_policy
+      }
+    }
+
+    assert {:ok, expected_command} == Commands.decode(expected_bin)
+  end
+
+  test "encode/1" do
+    advertising_interval_min = 0x800
+    advertising_interval_max = 0x800
+    advertising_type = 0x000
+    own_address_type = 0x000
+    peer_address_type = 0x000
+    peer_address = <<0, 0, 0, 0, 0, 0>>
+    advertising_channel_map = 0x007
+    advertising_filter_policy = 0x000
+
+    parameters =
+      <<advertising_interval_min::little-size(16), advertising_interval_max::little-size(16),
+        advertising_type, own_address_type, peer_address_type,
+        peer_address::binary-little-size(6), advertising_channel_map, advertising_filter_policy>>
+
+    parameters_length = byte_size(parameters)
+    expected_bin = <<1, 6, 32, parameters_length, parameters::binary>>
+    expected_size = byte_size(expected_bin)
+
+    parameters = %{
+      advertising_interval_min: advertising_interval_min,
+      advertising_interval_max: advertising_interval_max,
+      advertising_type: advertising_type,
+      own_address_type: own_address_type,
+      peer_address_type: peer_address_type,
+      peer_address: peer_address,
+      advertising_channel_map: advertising_channel_map,
+      advertising_filter_policy: advertising_filter_policy
+    }
+
+    assert {:ok, actual_bin} =
+             Commands.encode(LEController, LESetAdvertisingParameters, parameters)
+
+    assert expected_size == byte_size(actual_bin)
+    assert expected_bin == actual_bin
+  end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             LESetAdvertisingParameters.decode_return_parameters(return_parameters)
+  end
+
+  test "encode_return_parameters/1" do
+    status = 1
+    encoded_return_parameters = <<status>>
+    decoded_return_parameters = %{status: status}
+
+    assert {:ok, encoded_return_parameters} ==
+             LESetAdvertisingParameters.encode_return_parameters(decoded_return_parameters)
+  end
+end

--- a/test/harald/hci/commands/le_controller/le_set_event_mask_test.exs
+++ b/test/harald/hci/commands/le_controller/le_set_event_mask_test.exs
@@ -1,0 +1,283 @@
+defmodule Harald.HCI.Commands.ControllerAndBaseband.LESetEventMaskTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.Commands.{Command, LEController}
+  alias Harald.HCI.{Commands, Commands.LEController.LESetEventMask}
+
+  test "decode/1" do
+    decoded_le_event_mask = %{
+      le_connection_complete_event: 1,
+      le_advertising_report_event: 1,
+      le_connection_update_complete_event: 1,
+      le_read_remote_features_complete_event: 1,
+      le_long_term_key_request_event: 1,
+      le_remote_connection_parameter_request_event: 1,
+      le_data_length_change_event: 1,
+      le_read_local_p256_public_key_complete_event: 1,
+      le_generate_dhkey_complete_event: 1,
+      le_enhanced_connection_complete_event: 1,
+      le_directed_advertising_report_event: 1,
+      le_phy_update_complete_event: 1,
+      le_extended_advertising_report_event: 1,
+      le_periodic_advertising_sync_established_event: 1,
+      le_periodic_advertising_report_event: 1,
+      le_periodic_advertising_sync_lost_event: 1,
+      le_scan_timeout_event: 1,
+      le_advertising_set_terminated_event: 1,
+      le_scan_request_received_event: 1,
+      le_channel_selection_algorithm_event: 1,
+      le_connectionless_iq_report_event: 1,
+      le_connection_iq_report_event: 1,
+      le_cte_request_failed_event: 1,
+      le_periodic_advertising_sync_transfer_received_event: 1,
+      le_cis_established_event: 1,
+      le_cis_request_event: 1,
+      le_create_big_complete_event: 1,
+      le_terminate_big_complete_event: 1,
+      le_big_sync_established_event: 1,
+      le_big_sync_lost_event: 1,
+      le_request_peer_sca_complete_event: 1,
+      le_path_loss_threshold_event: 1,
+      le_transmit_power_reporting_event: 1,
+      le_biginfo_advertising_report_event: 1
+    }
+
+    le_event_mask = <<
+      decoded_le_event_mask.le_connection_complete_event::size(1),
+      decoded_le_event_mask.le_advertising_report_event::size(1),
+      decoded_le_event_mask.le_connection_update_complete_event::size(1),
+      decoded_le_event_mask.le_read_remote_features_complete_event::size(1),
+      decoded_le_event_mask.le_long_term_key_request_event::size(1),
+      decoded_le_event_mask.le_remote_connection_parameter_request_event::size(1),
+      decoded_le_event_mask.le_data_length_change_event::size(1),
+      decoded_le_event_mask.le_read_local_p256_public_key_complete_event::size(1),
+      decoded_le_event_mask.le_generate_dhkey_complete_event::size(1),
+      decoded_le_event_mask.le_enhanced_connection_complete_event::size(1),
+      decoded_le_event_mask.le_directed_advertising_report_event::size(1),
+      decoded_le_event_mask.le_phy_update_complete_event::size(1),
+      decoded_le_event_mask.le_extended_advertising_report_event::size(1),
+      decoded_le_event_mask.le_periodic_advertising_sync_established_event::size(1),
+      decoded_le_event_mask.le_periodic_advertising_report_event::size(1),
+      decoded_le_event_mask.le_periodic_advertising_sync_lost_event::size(1),
+      decoded_le_event_mask.le_scan_timeout_event::size(1),
+      decoded_le_event_mask.le_advertising_set_terminated_event::size(1),
+      decoded_le_event_mask.le_scan_request_received_event::size(1),
+      decoded_le_event_mask.le_channel_selection_algorithm_event::size(1),
+      decoded_le_event_mask.le_connectionless_iq_report_event::size(1),
+      decoded_le_event_mask.le_connection_iq_report_event::size(1),
+      decoded_le_event_mask.le_cte_request_failed_event::size(1),
+      decoded_le_event_mask.le_periodic_advertising_sync_transfer_received_event::size(1),
+      decoded_le_event_mask.le_cis_established_event::size(1),
+      decoded_le_event_mask.le_cis_request_event::size(1),
+      decoded_le_event_mask.le_create_big_complete_event::size(1),
+      decoded_le_event_mask.le_terminate_big_complete_event::size(1),
+      decoded_le_event_mask.le_big_sync_established_event::size(1),
+      decoded_le_event_mask.le_big_sync_lost_event::size(1),
+      decoded_le_event_mask.le_request_peer_sca_complete_event::size(1),
+      decoded_le_event_mask.le_path_loss_threshold_event::size(1),
+      decoded_le_event_mask.le_transmit_power_reporting_event::size(1),
+      decoded_le_event_mask.le_biginfo_advertising_report_event::size(1)
+    >>
+
+    reserved = 0
+
+    decoded_le_event_mask = %{
+      le_advertising_report_event: true,
+      le_advertising_set_terminated_event: true,
+      le_big_sync_established_event: true,
+      le_big_sync_lost_event: true,
+      le_biginfo_advertising_report_event: true,
+      le_channel_selection_algorithm_event: true,
+      le_cis_established_event: true,
+      le_cis_request_event: true,
+      le_connection_complete_event: true,
+      le_connection_iq_report_event: true,
+      le_connection_update_complete_event: true,
+      le_connectionless_iq_report_event: true,
+      le_create_big_complete_event: true,
+      le_cte_request_failed_event: true,
+      le_data_length_change_event: true,
+      le_directed_advertising_report_event: true,
+      le_enhanced_connection_complete_event: true,
+      le_extended_advertising_report_event: true,
+      le_generate_dhkey_complete_event: true,
+      le_long_term_key_request_event: true,
+      le_path_loss_threshold_event: true,
+      le_periodic_advertising_report_event: true,
+      le_periodic_advertising_sync_established_event: true,
+      le_periodic_advertising_sync_lost_event: true,
+      le_periodic_advertising_sync_transfer_received_event: true,
+      le_phy_update_complete_event: true,
+      le_read_local_p256_public_key_complete_event: true,
+      le_read_remote_features_complete_event: true,
+      le_remote_connection_parameter_request_event: true,
+      le_request_peer_sca_complete_event: true,
+      le_scan_request_received_event: true,
+      le_scan_timeout_event: true,
+      le_terminate_big_complete_event: true,
+      le_transmit_power_reporting_event: true,
+      reserved: <<reserved::size(30)>>
+    }
+
+    parameters = <<le_event_mask::bits, 0::size(30)>>
+    parameters_length = byte_size(parameters)
+    expected_bin = <<1, 1, 32, parameters_length, parameters::binary>>
+
+    expected_command = %Command{
+      command_op_code: %{
+        ocf: 0x01,
+        ocf_module: LESetEventMask,
+        ogf: 0x08,
+        ogf_module: LEController
+      },
+      parameters: %{
+        le_event_mask: decoded_le_event_mask
+      }
+    }
+
+    assert {:ok, expected_command} == Commands.decode(expected_bin)
+  end
+
+  test "encode/1" do
+    decoded_le_event_mask = %{
+      le_connection_complete_event: 1,
+      le_advertising_report_event: 1,
+      le_connection_update_complete_event: 1,
+      le_read_remote_features_complete_event: 1,
+      le_long_term_key_request_event: 1,
+      le_remote_connection_parameter_request_event: 1,
+      le_data_length_change_event: 1,
+      le_read_local_p256_public_key_complete_event: 1,
+      le_generate_dhkey_complete_event: 1,
+      le_enhanced_connection_complete_event: 1,
+      le_directed_advertising_report_event: 1,
+      le_phy_update_complete_event: 1,
+      le_extended_advertising_report_event: 1,
+      le_periodic_advertising_sync_established_event: 1,
+      le_periodic_advertising_report_event: 1,
+      le_periodic_advertising_sync_lost_event: 1,
+      le_scan_timeout_event: 1,
+      le_advertising_set_terminated_event: 1,
+      le_scan_request_received_event: 1,
+      le_channel_selection_algorithm_event: 1,
+      le_connectionless_iq_report_event: 1,
+      le_connection_iq_report_event: 1,
+      le_cte_request_failed_event: 1,
+      le_periodic_advertising_sync_transfer_received_event: 1,
+      le_cis_established_event: 1,
+      le_cis_request_event: 1,
+      le_create_big_complete_event: 1,
+      le_terminate_big_complete_event: 1,
+      le_big_sync_established_event: 1,
+      le_big_sync_lost_event: 1,
+      le_request_peer_sca_complete_event: 1,
+      le_path_loss_threshold_event: 1,
+      le_transmit_power_reporting_event: 1,
+      le_biginfo_advertising_report_event: 1
+    }
+
+    le_event_mask = <<
+      decoded_le_event_mask.le_connection_complete_event::size(1),
+      decoded_le_event_mask.le_advertising_report_event::size(1),
+      decoded_le_event_mask.le_connection_update_complete_event::size(1),
+      decoded_le_event_mask.le_read_remote_features_complete_event::size(1),
+      decoded_le_event_mask.le_long_term_key_request_event::size(1),
+      decoded_le_event_mask.le_remote_connection_parameter_request_event::size(1),
+      decoded_le_event_mask.le_data_length_change_event::size(1),
+      decoded_le_event_mask.le_read_local_p256_public_key_complete_event::size(1),
+      decoded_le_event_mask.le_generate_dhkey_complete_event::size(1),
+      decoded_le_event_mask.le_enhanced_connection_complete_event::size(1),
+      decoded_le_event_mask.le_directed_advertising_report_event::size(1),
+      decoded_le_event_mask.le_phy_update_complete_event::size(1),
+      decoded_le_event_mask.le_extended_advertising_report_event::size(1),
+      decoded_le_event_mask.le_periodic_advertising_sync_established_event::size(1),
+      decoded_le_event_mask.le_periodic_advertising_report_event::size(1),
+      decoded_le_event_mask.le_periodic_advertising_sync_lost_event::size(1),
+      decoded_le_event_mask.le_scan_timeout_event::size(1),
+      decoded_le_event_mask.le_advertising_set_terminated_event::size(1),
+      decoded_le_event_mask.le_scan_request_received_event::size(1),
+      decoded_le_event_mask.le_channel_selection_algorithm_event::size(1),
+      decoded_le_event_mask.le_connectionless_iq_report_event::size(1),
+      decoded_le_event_mask.le_connection_iq_report_event::size(1),
+      decoded_le_event_mask.le_cte_request_failed_event::size(1),
+      decoded_le_event_mask.le_periodic_advertising_sync_transfer_received_event::size(1),
+      decoded_le_event_mask.le_cis_established_event::size(1),
+      decoded_le_event_mask.le_cis_request_event::size(1),
+      decoded_le_event_mask.le_create_big_complete_event::size(1),
+      decoded_le_event_mask.le_terminate_big_complete_event::size(1),
+      decoded_le_event_mask.le_big_sync_established_event::size(1),
+      decoded_le_event_mask.le_big_sync_lost_event::size(1),
+      decoded_le_event_mask.le_request_peer_sca_complete_event::size(1),
+      decoded_le_event_mask.le_path_loss_threshold_event::size(1),
+      decoded_le_event_mask.le_transmit_power_reporting_event::size(1),
+      decoded_le_event_mask.le_biginfo_advertising_report_event::size(1)
+    >>
+
+    reserved = 0
+
+    decoded_le_event_mask = %{
+      le_advertising_report_event: true,
+      le_advertising_set_terminated_event: true,
+      le_big_sync_established_event: true,
+      le_big_sync_lost_event: true,
+      le_biginfo_advertising_report_event: true,
+      le_channel_selection_algorithm_event: true,
+      le_cis_established_event: true,
+      le_cis_request_event: true,
+      le_connection_complete_event: true,
+      le_connection_iq_report_event: true,
+      le_connection_update_complete_event: true,
+      le_connectionless_iq_report_event: true,
+      le_create_big_complete_event: true,
+      le_cte_request_failed_event: true,
+      le_data_length_change_event: true,
+      le_directed_advertising_report_event: true,
+      le_enhanced_connection_complete_event: true,
+      le_extended_advertising_report_event: true,
+      le_generate_dhkey_complete_event: true,
+      le_long_term_key_request_event: true,
+      le_path_loss_threshold_event: true,
+      le_periodic_advertising_report_event: true,
+      le_periodic_advertising_sync_established_event: true,
+      le_periodic_advertising_sync_lost_event: true,
+      le_periodic_advertising_sync_transfer_received_event: true,
+      le_phy_update_complete_event: true,
+      le_read_local_p256_public_key_complete_event: true,
+      le_read_remote_features_complete_event: true,
+      le_remote_connection_parameter_request_event: true,
+      le_request_peer_sca_complete_event: true,
+      le_scan_request_received_event: true,
+      le_scan_timeout_event: true,
+      le_terminate_big_complete_event: true,
+      le_transmit_power_reporting_event: true,
+      reserved: <<reserved::size(30)>>
+    }
+
+    parameters = <<le_event_mask::bits, 0::size(30)>>
+    parameters_length = byte_size(parameters)
+    expected_bin = <<1, 1, 32, parameters_length, parameters::binary>>
+    expected_size = byte_size(expected_bin)
+    parameters = %{le_event_mask: decoded_le_event_mask}
+
+    assert {:ok, actual_bin} = Commands.encode(LEController, LESetEventMask, parameters)
+    assert expected_size == byte_size(actual_bin)
+    assert expected_bin == actual_bin
+  end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             LESetEventMask.decode_return_parameters(return_parameters)
+  end
+
+  test "encode_return_parameters/1" do
+    status = 1
+    encoded_return_parameters = <<status>>
+    decoded_return_parameters = %{status: status}
+
+    assert {:ok, encoded_return_parameters} ==
+             LESetEventMask.encode_return_parameters(decoded_return_parameters)
+  end
+end

--- a/test/harald/hci/events/command_complete_test.exs
+++ b/test/harald/hci/events/command_complete_test.exs
@@ -1,0 +1,77 @@
+defmodule Harald.HCI.Events.CommandCompleteTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.Events
+  alias Harald.HCI.Events.CommandComplete
+  alias Harald.HCI.Commands.{ControllerAndBaseband, ControllerAndBaseband.ReadLocalName}
+
+  doctest Events, import: true
+
+  describe "decode" do
+    num_hci_command_packets = 10
+    return_parameters = <<254, 0>>
+    command_op_code = <<1, 55>>
+    bin = <<num_hci_command_packets>> <> command_op_code <> return_parameters
+
+    expected = %{
+      command_op_code: %{
+        ocf: 769,
+        ocf_module: :not_implemented,
+        ogf: 13,
+        ogf_module: :not_implemented
+      },
+      num_hci_command_packets: num_hci_command_packets,
+      return_parameters: return_parameters
+    }
+
+    assert {:ok, actual} = CommandComplete.decode(bin)
+    assert expected == actual
+  end
+
+  describe "encode/1" do
+    num_hci_command_packets = 10
+    local_name = String.pad_trailing("bob", 248, <<0>>)
+    status = 0
+    encoded_return_parameters = <<status, local_name::binary>>
+    decoded_return_parameters = %{local_name: local_name, status: status}
+    command_op_code = <<20, 12>>
+    expected = <<num_hci_command_packets>> <> command_op_code <> encoded_return_parameters
+
+    parameters = %{
+      command_op_code: %{
+        ocf: 0x14,
+        ocf_module: ReadLocalName,
+        ogf: 0x03,
+        ogf_module: ControllerAndBaseband
+      },
+      num_hci_command_packets: num_hci_command_packets,
+      return_parameters: decoded_return_parameters
+    }
+
+    assert {:ok, actual} = CommandComplete.encode(parameters)
+    assert expected == actual
+  end
+
+  describe "decode/1" do
+    num_hci_command_packets = 10
+    local_name = String.pad_trailing("bob", 248, <<0>>)
+    status = 0
+    encoded_return_parameters = <<status, local_name::binary>>
+    decoded_return_parameters = %{local_name: local_name, status: status}
+    command_op_code = <<20, 12>>
+    bin = <<num_hci_command_packets>> <> command_op_code <> encoded_return_parameters
+
+    expected = %{
+      command_op_code: %{
+        ocf: 0x14,
+        ocf_module: ReadLocalName,
+        ogf: 0x03,
+        ogf_module: ControllerAndBaseband
+      },
+      num_hci_command_packets: num_hci_command_packets,
+      return_parameters: decoded_return_parameters
+    }
+
+    assert {:ok, actual} = CommandComplete.decode(bin)
+    assert expected == actual
+  end
+end

--- a/test/harald/hci/events/le_meta/connection_complete_test.exs
+++ b/test/harald/hci/events/le_meta/connection_complete_test.exs
@@ -1,0 +1,85 @@
+defmodule Harald.HCI.Events.LEMeta.ConnectionCompleteTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.Events.LEMeta.ConnectionComplete
+  alias Harald.HCI.Commands.LEController.LESetAdvertisingEnable
+
+  test "decode/1" do
+    status = 0
+    connection_handle = <<1, 2>>
+    role = 0x01
+    peer_address_type = 0x01
+    peer_address = <<1, 2, 3, 4, 5, 6>>
+    connection_interval = 0x0C80
+    connection_latency = 0x01F3
+    supervision_timeout = 0xC80
+    master_clock_accuracy = 0x01
+
+    bin =
+      <<status, connection_handle::binary-little-size(2), role, peer_address_type,
+        peer_address::binary-little-size(6), connection_interval::little-size(16),
+        connection_latency::little-size(16), supervision_timeout::little-size(16),
+        master_clock_accuracy>>
+
+    expected_parameters = %{
+      status: status,
+      connection_handle: connection_handle,
+      role: role,
+      peer_address_type: peer_address_type,
+      peer_address: peer_address,
+      connection_interval: connection_interval,
+      connection_latency: connection_latency,
+      supervision_timeout: supervision_timeout,
+      master_clock_accuracy: master_clock_accuracy
+    }
+
+    assert {:ok, expected_parameters} == ConnectionComplete.decode(bin)
+  end
+
+  test "encode/1" do
+    status = 0
+    connection_handle = <<1, 2>>
+    role = 0x01
+    peer_address_type = 0x01
+    peer_address = <<1, 2, 3, 4, 5, 6>>
+    connection_interval = 0x0C80
+    connection_latency = 0x01F3
+    supervision_timeout = 0xC80
+    master_clock_accuracy = 0x01
+
+    expected_bin = <<
+      status,
+      connection_handle::binary-little-size(2),
+      role,
+      peer_address_type,
+      peer_address::binary-little-size(6),
+      connection_interval::little-size(16),
+      connection_latency::little-size(16),
+      supervision_timeout::little-size(16),
+      master_clock_accuracy
+    >>
+
+    parameters = %{
+      status: status,
+      connection_handle: connection_handle,
+      role: role,
+      peer_address_type: peer_address_type,
+      peer_address: peer_address,
+      connection_interval: connection_interval,
+      connection_latency: connection_latency,
+      supervision_timeout: supervision_timeout,
+      master_clock_accuracy: master_clock_accuracy
+    }
+
+    assert {:ok, actual_bin} = ConnectionComplete.encode(parameters)
+    assert expected_bin == actual_bin
+  end
+
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             LESetAdvertisingEnable.decode_return_parameters(return_parameters)
+  end
+end

--- a/test/harald/hci/events/le_meta_test.exs
+++ b/test/harald/hci/events/le_meta_test.exs
@@ -1,0 +1,49 @@
+defmodule Harald.HCI.Events.LEMetaTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.Events.{LEMeta, LEMeta.ConnectionComplete}
+
+  describe "decode" do
+    sub_event_code = ConnectionComplete.sub_event_code()
+    sub_event_module = ConnectionComplete
+    status = 0
+    connection_handle = <<1, 2>>
+    role = 0x01
+    peer_address_type = 0x01
+    peer_address = <<1, 2, 3, 4, 5, 6>>
+    connection_interval = 0x0C80
+    connection_latency = 0x01F3
+    supervision_timeout = 0xC80
+    master_clock_accuracy = 0x01
+
+    encoded_sub_event_parameters =
+      <<status, connection_handle::binary-little-size(2), role, peer_address_type,
+        peer_address::binary-little-size(6), connection_interval::little-size(16),
+        connection_latency::little-size(16), supervision_timeout::little-size(16),
+        master_clock_accuracy>>
+
+    decoded_subevent_parameters = %{
+      status: status,
+      connection_handle: connection_handle,
+      role: role,
+      peer_address_type: peer_address_type,
+      peer_address: peer_address,
+      connection_interval: connection_interval,
+      connection_latency: connection_latency,
+      supervision_timeout: supervision_timeout,
+      master_clock_accuracy: master_clock_accuracy
+    }
+
+    encoded_le_meta = <<sub_event_code, encoded_sub_event_parameters::binary>>
+
+    decoded_le_meta = %{
+      sub_event: %{code: sub_event_code, module: sub_event_module},
+      sub_event_parameters: decoded_subevent_parameters
+    }
+
+    assert {:ok, actual_decoded_le_meta} = LEMeta.decode(encoded_le_meta)
+    assert decoded_le_meta == actual_decoded_le_meta
+  end
+
+  describe "encode/1" do
+  end
+end


### PR DESCRIPTION
- Add and update tests.
- Add "c:Command.encode_return_parameters/1".
- Add "Events.encode/1".
- Add "Events.event_code_to_module/1" clause for "LEMeta".
- Update "Event" struct fields: remove event_code and add code and
  module.
- Fix "CommandComplete.encode/1" implementation.
- Implement "LEMeta".
- Add ConnectionComplete.