### PR TITLE
Fix HCI framing bug

### DIFF
--- a/lib/harald/hci/transport/uart/framing.ex
+++ b/lib/harald/hci/transport/uart/framing.ex
@@ -75,25 +75,55 @@ defmodule Harald.HCI.Transport.UART.Framing do
 
   # HCI ACL Data Packet
   defp process_data(
-         <<2, _::size(16), length::size(16)>> <> data,
+         <<
+           2,
+           handle::size(12),
+           pb_flag::size(2),
+           bc_flag::size(2),
+           length::little-size(16),
+           data::binary
+         >>,
          %State{frame: <<>>} = state,
          messages
        ) do
-    process_data(data, length, state, messages)
+    frame = <<
+      2,
+      handle::size(12),
+      pb_flag::size(2),
+      bc_flag::size(2),
+      length::little-size(16)
+    >>
+
+    process_data(data, length, %{state | frame: frame}, messages)
   end
 
   # HCI Synchronous Data Packet
   defp process_data(
-         <<3, _::size(16), length::size(8)>> <> data,
+         <<
+           3,
+           connection_handle::size(12),
+           packet_status_flag::size(2),
+           rfu::size(2),
+           length::little-size(16),
+           data::binary
+         >>,
          %State{frame: <<>>} = state,
          messages
        ) do
-    process_data(data, length, state, messages)
+    frame = <<
+      3,
+      connection_handle::size(12),
+      packet_status_flag::size(2),
+      rfu::size(2),
+      length::little-size(16)
+    >>
+
+    process_data(data, length, %{state | frame: frame}, messages)
   end
 
   # HCI Event Packet
   defp process_data(
-         <<4, event_code::size(8), parameter_total_length::size(8), event_parameters::bits>>,
+         <<4, event_code::size(8), parameter_total_length::size(8), event_parameters::binary>>,
          %State{frame: <<>>} = state,
          messages
        ) do
@@ -107,7 +137,7 @@ defmodule Harald.HCI.Transport.UART.Framing do
 
   # bad packet type
   defp process_data(
-         <<indicator, _::bits>> = data,
+         <<indicator, _::binary>> = data,
          %State{frame: <<>>} = state,
          messages
        )

--- a/test/harald/transport/uart/framing_test.exs
+++ b/test/harald/transport/uart/framing_test.exs
@@ -1,85 +1,113 @@
 defmodule Harald.Transport.UART.FramingTest do
-  # use ExUnit.Case, async: true
-  # use ExUnitProperties
-  # alias Harald.Generators
-  # alias Harald.Transport.UART.Framing
-  # alias Harald.Transport.UART.Framing.State
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+  alias Harald.HCI.Transport.UART.Framing
+  alias Harald.HCI.Transport.UART.Framing.State
 
-  # doctest Harald.Transport.UART.Framing, import: true
+  doctest Harald.HCI.Transport.UART.Framing, import: true
 
-  # describe "init/1" do
-  #   property "returns a fresh state" do
-  #     check all args <- StreamData.term() do
-  #       assert {:ok, %State{}} == Framing.init(args)
-  #     end
-  #   end
-  # end
+  describe "init/1" do
+    property "returns a fresh state" do
+      check all(args <- StreamData.term()) do
+        assert {:ok, %State{}} == Framing.init(args)
+      end
+    end
+  end
 
-  # describe "add_framing/2" do
-  #   property "returns data and state unchanged" do
-  #     check all data <- StreamData.binary(),
-  #               state <- StreamData.term() do
-  #       assert {:ok, data, state} == Framing.add_framing(data, state)
-  #     end
-  #   end
-  # end
+  describe "add_framing/2" do
+    property "returns data and state unchanged" do
+      check all(
+              data <- StreamData.binary(),
+              state <- StreamData.term()
+            ) do
+        assert {:ok, data, state} == Framing.add_framing(data, state)
+      end
+    end
+  end
 
-  # describe "flush/2" do
-  #   property ":transmit returns state unchanged" do
-  #     check all state <- StreamData.term() do
-  #       assert state == Framing.flush(:transmit, state)
-  #     end
-  #   end
+  describe "flush/2" do
+    property ":transmit returns state unchanged" do
+      check all(state <- StreamData.term()) do
+        assert state == Framing.flush(:transmit, state)
+      end
+    end
 
-  #   property ":receive returns a fresh state" do
-  #     check all state <- StreamData.term() do
-  #       assert %State{} == Framing.flush(:receive, state)
-  #     end
-  #   end
+    property ":receive returns a fresh state" do
+      check all(state <- StreamData.term()) do
+        assert %State{} == Framing.flush(:receive, state)
+      end
+    end
 
-  #   property ":both returns a fresh state" do
-  #     check all state <- StreamData.term() do
-  #       assert %State{} == Framing.flush(:both, state)
-  #     end
-  #   end
-  # end
+    property ":both returns a fresh state" do
+      check all(state <- StreamData.term()) do
+        assert %State{} == Framing.flush(:both, state)
+      end
+    end
+  end
 
-  # describe "frame_timeout/1" do
-  #   property "returns the state and an empty binary" do
-  #     check all state <- StreamData.term() do
-  #       assert {:ok, [state], <<>>} == Framing.frame_timeout(state)
-  #     end
-  #   end
-  # end
+  describe "frame_timeout/1" do
+    property "returns the state and an empty binary" do
+      check all(state <- StreamData.term()) do
+        assert {:ok, [state], <<>>} == Framing.frame_timeout(state)
+      end
+    end
+  end
 
-  # describe "remove_framing/2" do
-  #   property "bad packet types return the remaining data in error" do
-  #     check all packet_type <- StreamData.integer(),
-  #               packet_type not in 2..4,
-  #               rest <- StreamData.bitstring(),
-  #               binary = <<packet_type, rest::bits>> do
-  #       assert {:ok, [{:error, {:bad_packet_type, binary}}], %State{}} ==
-  #                Framing.remove_framing(binary, %State{})
-  #     end
-  #   end
+  describe "remove_framing/2" do
+    property "bad packet types return the remaining data in error" do
+      check all(
+              packet_type <- StreamData.integer(),
+              packet_type not in 2..4,
+              rest <- StreamData.binary(),
+              binary = <<packet_type, rest::binary>>
+            ) do
+        assert {:ok, [{:error, {:bad_packet_type, binary}}], %State{}} ==
+                 Framing.remove_framing(binary, %State{})
+      end
+    end
 
-  #   property "returns when receiving a complete binary of packets" do
-  #     check all packets <- StreamData.list_of(Generators.HCI.packet()),
-  #               binary = Enum.join(packets) do
-  #       assert {:ok, ^packets, %{frame: "", remaining_bytes: nil}} =
-  #                Framing.remove_framing(binary, %State{})
-  #     end
-  #   end
+    property "returns when receiving a complete binary of packets" do
+      check all(
+              tuples <-
+                StreamData.list_of({StreamData.integer(2..4), StreamData.binary()},
+                  min_length: 1
+                ),
+              max_runs: 1
+            ) do
+        packets =
+          Enum.map(tuples, fn
+            {2, binary} ->
+              length = byte_size(binary)
+              <<2, 1, 2, length::little-size(16), binary::binary>>
 
-  #   property "returns when receiving a binary of packets that will end in_frame" do
-  #     check all [head | tail] <- StreamData.list_of(Generators.HCI.packet(), length: 1),
-  #               packets = Enum.join(tail),
-  #               head_length = byte_size(head),
-  #               partial_length <- StreamData.integer(1..(head_length - 1)),
-  #               {0, partial_packet, _} = Framing.binary_split(head, partial_length) do
-  #       assert {:in_frame, ^tail, %{frame: ^partial_packet}} =
-  #                Framing.remove_framing(packets <> partial_packet, %State{})
-  #     end
-  #   end
-  # end
+            {3, binary} ->
+              length = byte_size(binary)
+              <<3, 1, 2, length::little-size(16), binary::binary>>
+
+            {4, binary} ->
+              length = byte_size(binary)
+              <<4, 0, length, binary::binary>>
+          end)
+
+        bin = Enum.join(packets)
+
+        assert {:ok, ^packets, %{frame: "", remaining_bytes: nil}} =
+                 Framing.remove_framing(bin, %State{})
+      end
+    end
+
+    property "returns when receiving a binary of packets that will end in_frame" do
+      check all(binaries <- StreamData.list_of(StreamData.binary(), min_length: 1)) do
+        [<<bin_head::binary-size(1), _bin_tail::binary>> | tail] =
+          Enum.map(binaries, fn binary ->
+            length = byte_size(binary)
+            <<4, 0, length, binary::binary>>
+          end)
+
+        bin = Enum.join(tail ++ [bin_head])
+
+        assert {:in_frame, ^tail, %{frame: ^bin_head}} = Framing.remove_framing(bin, %State{})
+      end
+    end
+  end
 end


### PR DESCRIPTION
What
----

- ACL and Synchronous Data packets' length field is 2 octets and as such
  needs to be decoded/encoded as little-endian. Prior to this commit
  this was not happening and could cause the Framing module to get stuck
  in frame and never return.

How
---

- Decode/encode the length field of ACL and Synchronous Data packets as
  little-endian.
- Update any "bits" specification to "binary" in Framing since we should
  only ever receive whole bytes.
- Update the Framing test.
  - Uncomment tests.
  - Remove references to vestigial Generators and replace with simple
    StreamData generators inline.
  - Update tests to exercise ACL and Synchronous Data packets in a
    manner that reproduces the relevant framing bug.