### PR TITLE
Improve event and command test coverage

### DIFF
--- a/lib/harald/hci/commands.ex
+++ b/lib/harald/hci/commands.ex
@@ -5,15 +5,17 @@ defmodule Harald.HCI.Commands do
 
   alias Harald.HCI.Packet
   alias Harald.HCI.Commands
-  alias Harald.HCI.Commands.{Command, CommandGroup, ControllerAndBaseband, LEController}
-
-  @type ogf() :: non_neg_integer()
+  alias Harald.HCI.Commands.{Command, ControllerAndBaseband, LEController}
 
   @type ocf() :: non_neg_integer()
-
+  @type ocf_module() :: module()
+  @type ogf() :: non_neg_integer()
   @type op_code() :: binary()
 
-  @spec header(ogf(), ocf(), non_neg_integer()) :: {:ok, binary()} | {:error, any()}
+  @callback decode(ocf(), binary()) :: {:ok, Command.t()} | :error
+  @callback ogf() :: ogf()
+  @callback ocf_to_module(ocf()) ::
+              {:ok, ocf_module()} | {:error, {:not_implemented, {module(), ocf()}}}
 
   def decode(bin) when is_binary(bin) do
     indicator = Packet.indicator(:command)
@@ -75,5 +77,5 @@ defmodule Harald.HCI.Commands do
 
   def ogf_to_module(0x03), do: {:ok, ControllerAndBaseband}
   def ogf_to_module(0x08), do: {:ok, LEController}
-  def ogf_to_module(ogf), do: {:error, {:not_implemented, {CommandGroup, ogf}}}
+  def ogf_to_module(ogf), do: {:error, {:not_implemented, {__MODULE__, ogf}}}
 end

--- a/lib/harald/hci/commands/command_group.ex
+++ b/lib/harald/hci/commands/command_group.ex
@@ -1,9 +1,0 @@
-defmodule Harald.HCI.Commands.CommandGroup do
-  alias Harald.HCI.Commands
-
-  @callback decode(Commands.ocf(), binary()) :: {:ok, Command.t()} | :error
-  @callback ogf() :: Commands.ogf()
-  @callback ocf_to_module(Commands.ocf()) ::
-              {:ok, Commands.ocf_module()}
-              | {:error, {:not_implemented, {module(), Commands.ocf()}}}
-end

--- a/lib/harald/hci/commands/controller_and_baseband.ex
+++ b/lib/harald/hci/commands/controller_and_baseband.ex
@@ -3,7 +3,7 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband do
   Reference: version 5.1, vol 2, part E, 7.3.
   """
 
-  alias Harald.HCI.Commands.CommandGroup
+  alias Harald.HCI.Commands
 
   alias Harald.HCI.Commands.ControllerAndBaseband.{
     ReadLocalName,
@@ -13,9 +13,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband do
     SetEventMask
   }
 
-  @behaviour CommandGroup
+  @behaviour Commands
 
-  @impl CommandGroup
+  @impl Commands
   def decode(ocf, bin) when is_integer(ocf) and is_binary(bin) do
     with {:ok, ocf_module} <- ocf_to_module(ocf),
          {:ok, parameters} <- ocf_module.decode(bin) do
@@ -23,10 +23,10 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband do
     end
   end
 
-  @impl CommandGroup
+  @impl Commands
   def ogf(), do: 0x03
 
-  @impl CommandGroup
+  @impl Commands
   def ocf_to_module(0x01), do: {:ok, SetEventMask}
   def ocf_to_module(0x0A), do: {:ok, WritePinType}
   def ocf_to_module(0x13), do: {:ok, WriteLocalName}

--- a/lib/harald/hci/commands/controller_and_baseband/read_local_name.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/read_local_name.ex
@@ -8,15 +8,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.ReadLocalName do
   @behaviour Command
 
   @impl Command
-  def encode(%{}), do: {:ok, <<>>}
-
-  @impl Command
   def decode(<<>>), do: {:ok, %{}}
 
   @impl Command
   def decode_return_parameters(<<status, local_name::binary-size(248)>>) do
     {:ok, %{status: status, local_name: local_name}}
   end
+
+  @impl Command
+  def encode(%{}), do: {:ok, <<>>}
 
   @impl Command
   def encode_return_parameters(%{status: status, local_name: local_name}) do

--- a/lib/harald/hci/commands/controller_and_baseband/write_pin_type.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/write_pin_type.ex
@@ -22,5 +22,5 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WritePinType do
   def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
 
   @impl Command
-  def ocf(), do: 0xA
+  def ocf(), do: 0x0A
 end

--- a/lib/harald/hci/commands/le_controller.ex
+++ b/lib/harald/hci/commands/le_controller.ex
@@ -3,7 +3,7 @@ defmodule Harald.HCI.Commands.LEController do
   Reference: version 5.2, vol 4, part E, 7.8.
   """
 
-  alias Harald.HCI.Commands.CommandGroup
+  alias Harald.HCI.Commands
 
   alias Harald.HCI.Commands.LEController.{
     SetAdvertisingData,
@@ -12,9 +12,9 @@ defmodule Harald.HCI.Commands.LEController do
     SetEventMask
   }
 
-  @behaviour CommandGroup
+  @behaviour Commands
 
-  @impl CommandGroup
+  @impl Commands
   def decode(ocf, bin) when is_integer(ocf) and is_binary(bin) do
     with {:ok, ocf_module} <- ocf_to_module(ocf),
          {:ok, parameters} <- ocf_module.decode(bin) do
@@ -22,10 +22,10 @@ defmodule Harald.HCI.Commands.LEController do
     end
   end
 
-  @impl CommandGroup
+  @impl Commands
   def ogf(), do: 0x08
 
-  @impl CommandGroup
+  @impl Commands
   def ocf_to_module(0x01), do: {:ok, SetEventMask}
   def ocf_to_module(0x06), do: {:ok, SetAdvertisingParameters}
   def ocf_to_module(0x08), do: {:ok, SetAdvertisingData}

--- a/lib/harald/hci/events/command_complete.ex
+++ b/lib/harald/hci/events/command_complete.ex
@@ -77,5 +77,5 @@ defmodule Harald.HCI.Events.CommandComplete do
   end
 
   @impl Event
-  def event_code(), do: 0xE
+  def event_code(), do: 0x0E
 end

--- a/lib/harald/hci/events/le_meta.ex
+++ b/lib/harald/hci/events/le_meta.ex
@@ -36,7 +36,7 @@ defmodule Harald.HCI.Events.LEMeta do
   end
 
   @impl Event
-  def event_code(), do: 0x13
+  def event_code(), do: 0x3E
 
   def new(sub_event_module, parameters) when is_atom(sub_event_module) and is_map(parameters) do
     event =

--- a/test/harald/hci/commands/controller_and_baseband/read_local_name_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/read_local_name_test.exs
@@ -19,15 +19,6 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.ReadLocalNameTest do
     assert {:ok, expected_command} == Commands.decode(expected_bin)
   end
 
-  test "encode/1" do
-    expected_bin = <<1, 20, 12, 0>>
-    expected_size = byte_size(expected_bin)
-    params = %{}
-    assert {:ok, actual_bin} = Commands.encode(ControllerAndBaseband, ReadLocalName, params)
-    assert expected_size == byte_size(actual_bin)
-    assert expected_bin == actual_bin
-  end
-
   test "decode_return_parameters/1" do
     status = 1
     local_name = "bob"
@@ -37,6 +28,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.ReadLocalNameTest do
 
     assert {:ok, expected_return_parameters} ==
              ReadLocalName.decode_return_parameters(return_parameters)
+  end
+
+  test "encode/1" do
+    expected_bin = <<1, 20, 12, 0>>
+    expected_size = byte_size(expected_bin)
+    params = %{}
+    assert {:ok, actual_bin} = Commands.encode(ControllerAndBaseband, ReadLocalName, params)
+    assert expected_size == byte_size(actual_bin)
+    assert expected_bin == actual_bin
   end
 
   test "encode_return_parameters/1" do
@@ -49,5 +49,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.ReadLocalNameTest do
 
     assert {:ok, encoded_return_parameters} ==
              ReadLocalName.encode_return_parameters(decoded_return_parameters)
+  end
+
+  test "ocf/0" do
+    assert 0x14 == ReadLocalName.ocf()
   end
 end

--- a/test/harald/hci/commands/controller_and_baseband/set_event_mask_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/set_event_mask_test.exs
@@ -193,6 +193,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMaskTest do
     assert {:ok, expected_command} == Commands.decode(expected_bin)
   end
 
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             SetEventMask.decode_return_parameters(return_parameters)
+  end
+
   test "encode/1" do
     decoded_event_mask = %{
       inquiry_complete_event: 1,
@@ -378,12 +387,16 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMaskTest do
     assert expected_bin == actual_bin
   end
 
-  test "decode_return_parameters/1" do
+  test "encode_return_parameters/1" do
     status = 1
-    return_parameters = <<status>>
-    expected_return_parameters = %{status: status}
+    encoded_return_parameters = <<status>>
+    decoded_return_parameters = %{status: status}
 
-    assert {:ok, expected_return_parameters} ==
-             SetEventMask.decode_return_parameters(return_parameters)
+    assert {:ok, encoded_return_parameters} ==
+             SetEventMask.encode_return_parameters(decoded_return_parameters)
+  end
+
+  test "ocf/0" do
+    assert 0x01 == SetEventMask.ocf()
   end
 end

--- a/test/harald/hci/commands/controller_and_baseband/write_local_name_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/write_local_name_test.exs
@@ -22,6 +22,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteLocalNameTest do
     assert {:ok, expected_command} == Commands.decode(expected_bin)
   end
 
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             WriteLocalName.decode_return_parameters(return_parameters)
+  end
+
   test "encode/1" do
     name = "bob"
     expected_name = String.pad_trailing(name, 248, <<0>>)
@@ -33,15 +42,6 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteLocalNameTest do
     assert expected_bin == actual_bin
   end
 
-  test "decode_return_parameters/1" do
-    status = 1
-    return_parameters = <<status>>
-    expected_return_parameters = %{status: status}
-
-    assert {:ok, expected_return_parameters} ==
-             WriteLocalName.decode_return_parameters(return_parameters)
-  end
-
   test "encode_return_parameters/1" do
     status = 1
     encoded_return_parameters = <<status>>
@@ -49,5 +49,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteLocalNameTest do
 
     assert {:ok, encoded_return_parameters} ==
              WriteLocalName.encode_return_parameters(decoded_return_parameters)
+  end
+
+  test "ocf/0" do
+    assert 0x13 == WriteLocalName.ocf()
   end
 end

--- a/test/harald/hci/commands/controller_and_baseband/write_pin_type_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/write_pin_type_test.exs
@@ -20,6 +20,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WritePinTypeTest do
     assert {:ok, expected_command} == Commands.decode(expected_bin)
   end
 
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             WritePinType.decode_return_parameters(return_parameters)
+  end
+
   test "encode/1" do
     pin_type = 0
     expected_bin = <<1, 10, 12, 1, pin_type>>
@@ -32,15 +41,6 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WritePinTypeTest do
     assert expected_bin == actual_bin
   end
 
-  test "decode_return_parameters/1" do
-    status = 1
-    return_parameters = <<status>>
-    expected_return_parameters = %{status: status}
-
-    assert {:ok, expected_return_parameters} ==
-             WritePinType.decode_return_parameters(return_parameters)
-  end
-
   test "encode_return_parameters/1" do
     status = 1
     encoded_return_parameters = <<status>>
@@ -48,5 +48,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WritePinTypeTest do
 
     assert {:ok, encoded_return_parameters} ==
              WritePinType.encode_return_parameters(decoded_return_parameters)
+  end
+
+  test "ocf/0" do
+    assert 0x0A == WritePinType.ocf()
   end
 end

--- a/test/harald/hci/commands/controller_and_baseband/write_simple_pairing_mode_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/write_simple_pairing_mode_test.exs
@@ -20,6 +20,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteSimplePairingModeTest d
     assert {:ok, expected_command} == Commands.decode(expected_bin)
   end
 
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             WriteSimplePairingMode.decode_return_parameters(return_parameters)
+  end
+
   test "encode/1" do
     simple_pairing_mode = 1
     expected_bin = <<1, 86, 12, 1, simple_pairing_mode>>
@@ -33,15 +42,6 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteSimplePairingModeTest d
     assert expected_bin == actual_bin
   end
 
-  test "decode_return_parameters/1" do
-    status = 1
-    return_parameters = <<status>>
-    expected_return_parameters = %{status: status}
-
-    assert {:ok, expected_return_parameters} ==
-             WriteSimplePairingMode.decode_return_parameters(return_parameters)
-  end
-
   test "encode_return_parameters/1" do
     status = 1
     encoded_return_parameters = <<status>>
@@ -49,5 +49,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.WriteSimplePairingModeTest d
 
     assert {:ok, encoded_return_parameters} ==
              WriteSimplePairingMode.encode_return_parameters(decoded_return_parameters)
+  end
+
+  test "ocf/0" do
+    assert 0x56 == WriteSimplePairingMode.ocf()
   end
 end

--- a/test/harald/hci/commands/controller_and_baseband_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband_test.exs
@@ -1,0 +1,8 @@
+defmodule Harald.HCI.Commands.ControllerAndBasebandTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.Commands.ControllerAndBaseband
+
+  test "ogf/1" do
+    assert 0x03 == ControllerAndBaseband.ogf()
+  end
+end

--- a/test/harald/hci/commands/le_controller/set_advertising_data_test.exs
+++ b/test/harald/hci/commands/le_controller/set_advertising_data_test.exs
@@ -30,6 +30,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetAdvertisingDataTest do
     assert {:ok, expected_decoded_parameters} == SetAdvertisingData.decode(encoded_parameters)
   end
 
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             SetAdvertisingData.decode_return_parameters(return_parameters)
+  end
+
   test "encode/1" do
     {decoded_ad_structure, encoded_ad_structure} = ad_structure_pair()
     encoded_advertising_data = encoded_ad_structure
@@ -61,15 +70,6 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetAdvertisingDataTest do
     assert {:ok, expected_encoded_parameters} == SetAdvertisingData.encode(decoded_parameters)
   end
 
-  test "decode_return_parameters/1" do
-    status = 1
-    return_parameters = <<status>>
-    expected_return_parameters = %{status: status}
-
-    assert {:ok, expected_return_parameters} ==
-             SetAdvertisingData.decode_return_parameters(return_parameters)
-  end
-
   test "encode_return_parameters/1" do
     status = 1
     encoded_return_parameters = <<status>>
@@ -77,6 +77,10 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetAdvertisingDataTest do
 
     assert {:ok, encoded_return_parameters} ==
              SetAdvertisingData.encode_return_parameters(decoded_return_parameters)
+  end
+
+  test "ocf/0" do
+    assert 0x08 == SetAdvertisingData.ocf()
   end
 
   defp ad_structure_pair() do

--- a/test/harald/hci/commands/le_controller/set_advertising_enable_test.exs
+++ b/test/harald/hci/commands/le_controller/set_advertising_enable_test.exs
@@ -24,6 +24,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetAdvertisingEnableTest do
     assert {:ok, expected_command} == Commands.decode(expected_bin)
   end
 
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             SetAdvertisingEnable.decode_return_parameters(return_parameters)
+  end
+
   test "encode/1" do
     {advertising_enable_encoded, advertising_enable_decoded} = {1, true}
     parameters = <<advertising_enable_encoded>>
@@ -39,15 +48,6 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetAdvertisingEnableTest do
     assert expected_bin == actual_bin
   end
 
-  test "decode_return_parameters/1" do
-    status = 1
-    return_parameters = <<status>>
-    expected_return_parameters = %{status: status}
-
-    assert {:ok, expected_return_parameters} ==
-             SetAdvertisingEnable.decode_return_parameters(return_parameters)
-  end
-
   test "encode_return_parameters/1" do
     status = 1
     encoded_return_parameters = <<status>>
@@ -55,5 +55,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetAdvertisingEnableTest do
 
     assert {:ok, encoded_return_parameters} ==
              SetAdvertisingEnable.encode_return_parameters(decoded_return_parameters)
+  end
+
+  test "ocf/0" do
+    assert 0x0A == SetAdvertisingEnable.ocf()
   end
 end

--- a/test/harald/hci/commands/le_controller/set_advertising_parameters_test.exs
+++ b/test/harald/hci/commands/le_controller/set_advertising_parameters_test.exs
@@ -43,6 +43,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetAdvertisingParametersTest
     assert {:ok, expected_command} == Commands.decode(expected_bin)
   end
 
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             SetAdvertisingParameters.decode_return_parameters(return_parameters)
+  end
+
   test "encode/1" do
     advertising_interval_min = 0x800
     advertising_interval_max = 0x800
@@ -79,15 +88,6 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetAdvertisingParametersTest
     assert expected_bin == actual_bin
   end
 
-  test "decode_return_parameters/1" do
-    status = 1
-    return_parameters = <<status>>
-    expected_return_parameters = %{status: status}
-
-    assert {:ok, expected_return_parameters} ==
-             SetAdvertisingParameters.decode_return_parameters(return_parameters)
-  end
-
   test "encode_return_parameters/1" do
     status = 1
     encoded_return_parameters = <<status>>
@@ -95,5 +95,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetAdvertisingParametersTest
 
     assert {:ok, encoded_return_parameters} ==
              SetAdvertisingParameters.encode_return_parameters(decoded_return_parameters)
+  end
+
+  test "ocf/0" do
+    assert 0x06 == SetAdvertisingParameters.ocf()
   end
 end

--- a/test/harald/hci/commands/le_controller/set_event_mask_test.exs
+++ b/test/harald/hci/commands/le_controller/set_event_mask_test.exs
@@ -137,6 +137,15 @@ defmodule Harald.HCI.Commands.LEController.SetEventMaskTest do
     assert {:ok, expected_command} == Commands.decode(expected_bin)
   end
 
+  test "decode_return_parameters/1" do
+    status = 1
+    return_parameters = <<status>>
+    expected_return_parameters = %{status: status}
+
+    assert {:ok, expected_return_parameters} ==
+             SetEventMask.decode_return_parameters(return_parameters)
+  end
+
   test "encode/1" do
     decoded_le_event_mask = %{
       le_connection_complete_event: 1,
@@ -263,15 +272,6 @@ defmodule Harald.HCI.Commands.LEController.SetEventMaskTest do
     assert expected_bin == actual_bin
   end
 
-  test "decode_return_parameters/1" do
-    status = 1
-    return_parameters = <<status>>
-    expected_return_parameters = %{status: status}
-
-    assert {:ok, expected_return_parameters} ==
-             SetEventMask.decode_return_parameters(return_parameters)
-  end
-
   test "encode_return_parameters/1" do
     status = 1
     encoded_return_parameters = <<status>>
@@ -279,5 +279,9 @@ defmodule Harald.HCI.Commands.LEController.SetEventMaskTest do
 
     assert {:ok, encoded_return_parameters} ==
              SetEventMask.encode_return_parameters(decoded_return_parameters)
+  end
+
+  test "ocf/0" do
+    assert 0x01 == SetEventMask.ocf()
   end
 end

--- a/test/harald/hci/commands/le_controller_test.exs
+++ b/test/harald/hci/commands/le_controller_test.exs
@@ -1,0 +1,8 @@
+defmodule Harald.HCI.Commands.LEControllerTest do
+  use ExUnit.Case, async: true
+  alias Harald.HCI.Commands.LEController
+
+  test "ogf/1" do
+    assert 0x08 == LEController.ogf()
+  end
+end

--- a/test/harald/hci/events/command_complete_test.exs
+++ b/test/harald/hci/events/command_complete_test.exs
@@ -6,28 +6,31 @@ defmodule Harald.HCI.Events.CommandCompleteTest do
 
   doctest Events, import: true
 
-  describe "decode" do
+  test "decode/1" do
     num_hci_command_packets = 10
-    return_parameters = <<254, 0>>
-    command_op_code = <<1, 55>>
-    bin = <<num_hci_command_packets>> <> command_op_code <> return_parameters
+    local_name = String.pad_trailing("bob", 248, <<0>>)
+    status = 0
+    encoded_return_parameters = <<status, local_name::binary>>
+    decoded_return_parameters = %{local_name: local_name, status: status}
+    command_op_code = <<20, 12>>
+    bin = <<num_hci_command_packets>> <> command_op_code <> encoded_return_parameters
 
     expected = %{
       command_op_code: %{
-        ocf: 769,
-        ocf_module: :not_implemented,
-        ogf: 13,
-        ogf_module: :not_implemented
+        ocf: 0x14,
+        ocf_module: ReadLocalName,
+        ogf: 0x03,
+        ogf_module: ControllerAndBaseband
       },
       num_hci_command_packets: num_hci_command_packets,
-      return_parameters: return_parameters
+      return_parameters: decoded_return_parameters
     }
 
     assert {:ok, actual} = CommandComplete.decode(bin)
     assert expected == actual
   end
 
-  describe "encode/1" do
+  test "encode/1" do
     num_hci_command_packets = 10
     local_name = String.pad_trailing("bob", 248, <<0>>)
     status = 0
@@ -51,27 +54,7 @@ defmodule Harald.HCI.Events.CommandCompleteTest do
     assert expected == actual
   end
 
-  describe "decode/1" do
-    num_hci_command_packets = 10
-    local_name = String.pad_trailing("bob", 248, <<0>>)
-    status = 0
-    encoded_return_parameters = <<status, local_name::binary>>
-    decoded_return_parameters = %{local_name: local_name, status: status}
-    command_op_code = <<20, 12>>
-    bin = <<num_hci_command_packets>> <> command_op_code <> encoded_return_parameters
-
-    expected = %{
-      command_op_code: %{
-        ocf: 0x14,
-        ocf_module: ReadLocalName,
-        ogf: 0x03,
-        ogf_module: ControllerAndBaseband
-      },
-      num_hci_command_packets: num_hci_command_packets,
-      return_parameters: decoded_return_parameters
-    }
-
-    assert {:ok, actual} = CommandComplete.decode(bin)
-    assert expected == actual
+  test "event_code/0" do
+    assert 0x0E == CommandComplete.event_code()
   end
 end

--- a/test/harald/hci/events/disconnection_complete_test.exs
+++ b/test/harald/hci/events/disconnection_complete_test.exs
@@ -43,4 +43,8 @@ defmodule Harald.HCI.Events.DisconnectionCompleteTest do
     assert {:ok, encoded_disconnection_complete} ==
              DisconnectionComplete.encode(decoded_disconnection_complete)
   end
+
+  test "event_code/0" do
+    assert 0x05 == DisconnectionComplete.event_code()
+  end
 end

--- a/test/harald/hci/events/le_meta/connection_complete_test.exs
+++ b/test/harald/hci/events/le_meta/connection_complete_test.exs
@@ -1,7 +1,6 @@
 defmodule Harald.HCI.Events.LEMeta.ConnectionCompleteTest do
   use ExUnit.Case, async: true
   alias Harald.HCI.Events.LEMeta.ConnectionComplete
-  alias Harald.HCI.Commands.LEController.SetAdvertisingEnable
 
   test "decode/1" do
     status = 0
@@ -74,12 +73,7 @@ defmodule Harald.HCI.Events.LEMeta.ConnectionCompleteTest do
     assert expected_bin == actual_bin
   end
 
-  test "decode_return_parameters/1" do
-    status = 1
-    return_parameters = <<status>>
-    expected_return_parameters = %{status: status}
-
-    assert {:ok, expected_return_parameters} ==
-             SetAdvertisingEnable.decode_return_parameters(return_parameters)
+  test "sub_event_code/0" do
+    assert 0x01 == ConnectionComplete.sub_event_code()
   end
 end

--- a/test/harald/hci/events/le_meta_test.exs
+++ b/test/harald/hci/events/le_meta_test.exs
@@ -2,7 +2,7 @@ defmodule Harald.HCI.Events.LEMetaTest do
   use ExUnit.Case, async: true
   alias Harald.HCI.Events.{LEMeta, LEMeta.ConnectionComplete}
 
-  describe "decode" do
+  test "decode/1" do
     sub_event_code = ConnectionComplete.sub_event_code()
     sub_event_module = ConnectionComplete
     status = 0
@@ -44,7 +44,7 @@ defmodule Harald.HCI.Events.LEMetaTest do
     assert decoded_le_meta == actual_decoded_le_meta
   end
 
-  describe "encode/1" do
+  test "encode/1" do
     sub_event_code = ConnectionComplete.sub_event_code()
     sub_event_module = ConnectionComplete
     status = 0
@@ -83,5 +83,9 @@ defmodule Harald.HCI.Events.LEMetaTest do
     }
 
     assert {:ok, encoded_le_meta} == LEMeta.encode(decoded_le_meta)
+  end
+
+  test "event_code/0" do
+    assert 0x3E == LEMeta.event_code()
   end
 end


### PR DESCRIPTION
- Add ocf/0 test for all commands.
- Add ogf/0 test for all commands groups.
- Add event_code/0 test for all events.
- Add sub_event_code/0 test for all LEMEta sub-events.
- Minor style consistency improvements.
- Absorb CommandGroup functionality into Commands.