### PR TITLE
Cleanup Error Responses

### DIFF
--- a/lib/harald/hci/events.ex
+++ b/lib/harald/hci/events.ex
@@ -19,9 +19,12 @@ defmodule Harald.HCI.Events do
   def decode(bin) when is_binary(bin) do
     case bin do
       <<event_code, _length, data::binary()>> ->
-        {:ok, event_module} = event_code_to_module(event_code)
-        {:ok, parameters} = event_module.decode(data)
-        Events.new(event_module, parameters)
+        with {:ok, event_module} <- event_code_to_module(event_code),
+             {:ok, parameters} <- event_module.decode(data) do
+          Events.new(event_module, parameters)
+        else
+          {:error, {:not_implemented, error, _bin}} -> {:error, {:not_implemented, error, bin}}
+        end
 
       <<>> ->
         :error


### PR DESCRIPTION
Why?

- Enable gracefull errors from :not_implemented errors in:
  - HCI.ACLData
  - Host.L2CAP
  - Host.ATT
  - Events
  - Events.LEMeta
- Allow Harald not to break on a :not_implemented error, gracefully pass
  error up to transport

How?

- Pattern match errors with :not_implemented atom