### PR TITLE
Modify ACLData.encode/1 to include HCI Packet Type

### DIFF
--- a/lib/harald/hci/acl_data.ex
+++ b/lib/harald/hci/acl_data.ex
@@ -4,6 +4,7 @@ defmodule Harald.HCI.ACLData do
   """
 
   alias Harald.Host.L2CAP
+  alias Harald.HCI.Packet
 
   @enforce_keys [
     :handle,
@@ -53,11 +54,13 @@ defmodule Harald.HCI.ACLData do
         data_total_length: data_total_length,
         data: data
       }) do
+    indicator = Packet.indicator(:acl_data)
     encoded_pb_flag = encode_pb_flag!(pb_flag)
     encoded_bc_flag = encode_bc_flag!(bc_flag)
     {:ok, encoded_data} = L2CAP.encode(data)
 
     encoded = <<
+      indicator,
       handle::bits-size(12),
       encoded_pb_flag::size(2),
       encoded_bc_flag::size(2),

--- a/test/harald/hci/acl_data_test.exs
+++ b/test/harald/hci/acl_data_test.exs
@@ -62,6 +62,7 @@ defmodule Harald.HCI.ACLDataTest do
   end
 
   test "encode/1" do
+    hci_packet_type = 2
     handle = <<1, 2::size(4)>>
     encoded_broadcast_flag = 0b00
     encoded_packet_boundary_flag = 0b01
@@ -108,6 +109,7 @@ defmodule Harald.HCI.ACLDataTest do
     }
 
     encoded_acl_data = <<
+      hci_packet_type::size(8),
       handle::bits-size(12),
       encoded_packet_boundary_flag::size(2),
       encoded_broadcast_flag::size(2),

--- a/test/harald_test.exs
+++ b/test/harald_test.exs
@@ -128,6 +128,7 @@ defmodule HaraldTest do
   end
 
   test "encode_acl_data/1" do
+    hci_packet_type = 2
     handle = <<1, 2::size(4)>>
     encoded_broadcast_flag = 0b00
     encoded_packet_boundary_flag = 0b01
@@ -174,6 +175,7 @@ defmodule HaraldTest do
     }
 
     encoded_acl_data = <<
+      hci_packet_type::size(8),
       handle::bits-size(12),
       encoded_packet_boundary_flag::size(2),
       encoded_broadcast_flag::size(2),


### PR DESCRIPTION
Why?
- Match Harald.encode_command expected output
- Allow Harald.encode_acl_data output to be entered into Harald.write/2 without
  modification

How?
- Modify lib/harald/hci/acl_data.ex to include packet type
- Modify ACLData tests to expect output

Side effects?
- ACLData.encode binary output change