### PR TITLE
Add ControllerAndBaseband.SetEvenMask.new/{1,2}

### DIFF
--- a/lib/harald/hci.ex
+++ b/lib/harald/hci.ex
@@ -3,7 +3,11 @@ defmodule Harald.HCI do
   Reference: version 5.1, vol 2, part E, 1.
   """
 
+  @type bit_range() :: Range.t()
+
   @type flag() :: boolean()
 
   @type reserved() :: non_neg_integer()
+
+  @type reserved_map() :: %{bit_range() => reserved()}
 end

--- a/lib/harald/hci/commands/controller_and_baseband/set_event_mask.ex
+++ b/lib/harald/hci/commands/controller_and_baseband/set_event_mask.ex
@@ -3,143 +3,121 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMask do
   Reference: version 5.2, Vol 4, Part E, 7.3.1.
   """
 
-  alias Harald.HCI.Commands.Command
+  alias Harald.{HCI, HCI.Commands.Command}
+
+  @type t() :: %{
+          event_mask: %{
+            inquiry_complete_event: HCI.flag(),
+            inquiry_result_event: HCI.flag(),
+            connection_complete_event: HCI.flag(),
+            connection_request_event: HCI.flag(),
+            disconnection_complete_event: HCI.flag(),
+            authentication_complete_event: HCI.flag(),
+            remote_name_request_complete_event: HCI.flag(),
+            encryption_change_event: HCI.flag(),
+            change_connection_link_key_complete_event: HCI.flag(),
+            mast_link_key_complete_event: HCI.flag(),
+            read_remote_supported_features_complete_event: HCI.flag(),
+            read_remote_version_information_complete_event: HCI.flag(),
+            qos_setup_complete_event: HCI.flag(),
+            hardware_error_event: HCI.flag(),
+            flush_occurred_event: HCI.flag(),
+            role_change_event: HCI.flag(),
+            mode_change_event: HCI.flag(),
+            return_link_keys_event: HCI.flag(),
+            pin_code_request_event: HCI.flag(),
+            link_key_request_event: HCI.flag(),
+            link_key_notification_event: HCI.flag(),
+            loopback_command_event: HCI.flag(),
+            data_buffer_overflow_event: HCI.flag(),
+            max_slots_change_event: HCI.flag(),
+            read_clock_offset_complete_event: HCI.flag(),
+            connection_packet_type_changed_event: HCI.flag(),
+            qos_violation_event: HCI.flag(),
+            page_scan_mode_change_event: HCI.flag(),
+            page_scan_repition_mode_change_event: HCI.flag(),
+            flow_specification_complete_event: HCI.flag(),
+            inquiry_result_with_rssi_event: HCI.flag(),
+            read_remote_extended_features_complete_event: HCI.flag(),
+            synchronous_connection_complete_event: HCI.flag(),
+            synchronous_connection_changed_event: HCI.flag(),
+            sniff_subrating_event: HCI.flag(),
+            extended_inquiry_result_event: HCI.flag(),
+            encryption_key_refresh_complete_event: HCI.flag(),
+            io_capability_request_event: HCI.flag(),
+            io_capability_response_event: HCI.flag(),
+            user_confirmation_request_event: HCI.flag(),
+            user_passkey_request_event: HCI.flag(),
+            remote_oob_data_request_event: HCI.flag(),
+            simple_pairing_complete_event: HCI.flag(),
+            link_supervision_timeout_changed_event: HCI.flag(),
+            enhanced_flush_complete_event: HCI.flag(),
+            user_passkey_notification_event: HCI.flag(),
+            keypress_notification_event: HCI.flag(),
+            remote_host_supported_features_notification_event: HCI.flag(),
+            le_meta_event: HCI.flag(),
+            reserved_map: HCI.reserved_map()
+          }
+        }
 
   @behaviour Command
 
-  @impl Command
-  def encode(%{
-        event_mask:
-          %{
-            inquiry_complete_event: _,
-            inquiry_result_event: _,
-            connection_complete_event: _,
-            connection_request_event: _,
-            disconnection_complete_event: _,
-            authentication_complete_event: _,
-            remote_name_request_complete_event: _,
-            encryption_change_event: _,
-            change_connection_link_key_complete_event: _,
-            mast_link_key_complete_event: _,
-            read_remote_supported_features_complete_event: _,
-            read_remote_version_information_complete_event: _,
-            qos_setup_complete_event: _,
-            hardware_error_event: _,
-            flush_occurred_evnet: _,
-            role_change_event: _,
-            mode_change_event: _,
-            return_link_keys_event: _,
-            pin_code_request_event: _,
-            link_key_request_event: _,
-            link_key_notification_event: _,
-            loopback_command_event: _,
-            data_buffer_overflow_event: _,
-            max_slots_change_event: _,
-            read_clock_offset_complete_event: _,
-            connection_packet_type_changed_event: _,
-            qos_violation_event: _,
-            page_scan_mode_change_event: _,
-            page_scan_repition_mode_change_event: _,
-            flow_specification_complete_event: _,
-            inquiry_result_with_rssi_event: _,
-            read_remote_extended_features_complete_event: _,
-            synchronous_connection_complete_event: _,
-            synchronous_connection_changed_event: _,
-            sniff_subrating_event: _,
-            extended_inquiry_result_event: _,
-            encryption_key_refresh_complete_event: _,
-            io_capability_request_event: _,
-            io_capability_response_event: _,
-            user_confirmation_request_event: _,
-            user_passkey_request_event: _,
-            remote_oob_data_request_event: _,
-            simple_pairing_complete_event: _,
-            link_supervision_timeout_changed_event: _,
-            enhanced_flush_complete_event: _,
-            user_passkey_notification_event: _,
-            keypress_notification_event: _,
-            remote_host_supported_features_notification_event: _,
-            le_meta_event: _,
-            reserved: <<_::bits-size(4)>>
-          } = decoded_event_mask
-      }) do
-    encoded_event_mask =
-      Enum.into(decoded_event_mask, %{}, fn
-        {:reserved, reserved} -> {:reserved, reserved}
-        {key, true} -> {key, 1}
-        {key, false} -> {key, 0}
-      end)
-
-    falsey = 0
-
-    {:ok,
-     <<
-       encoded_event_mask.inquiry_complete_event::size(1),
-       encoded_event_mask.inquiry_result_event::size(1),
-       encoded_event_mask.connection_complete_event::size(1),
-       encoded_event_mask.connection_request_event::size(1),
-       encoded_event_mask.disconnection_complete_event::size(1),
-       encoded_event_mask.authentication_complete_event::size(1),
-       encoded_event_mask.remote_name_request_complete_event::size(1),
-       encoded_event_mask.encryption_change_event::size(1),
-       encoded_event_mask.change_connection_link_key_complete_event::size(1),
-       encoded_event_mask.mast_link_key_complete_event::size(1),
-       encoded_event_mask.read_remote_supported_features_complete_event::size(1),
-       encoded_event_mask.read_remote_version_information_complete_event::size(1),
-       encoded_event_mask.qos_setup_complete_event::size(1),
-       falsey::size(1),
-       falsey::size(1),
-       encoded_event_mask.hardware_error_event::size(1),
-       encoded_event_mask.flush_occurred_evnet::size(1),
-       encoded_event_mask.role_change_event::size(1),
-       falsey::size(1),
-       encoded_event_mask.mode_change_event::size(1),
-       encoded_event_mask.return_link_keys_event::size(1),
-       encoded_event_mask.pin_code_request_event::size(1),
-       encoded_event_mask.link_key_request_event::size(1),
-       encoded_event_mask.link_key_notification_event::size(1),
-       encoded_event_mask.loopback_command_event::size(1),
-       encoded_event_mask.data_buffer_overflow_event::size(1),
-       encoded_event_mask.max_slots_change_event::size(1),
-       encoded_event_mask.read_clock_offset_complete_event::size(1),
-       encoded_event_mask.connection_packet_type_changed_event::size(1),
-       encoded_event_mask.qos_violation_event::size(1),
-       encoded_event_mask.page_scan_mode_change_event::size(1),
-       encoded_event_mask.page_scan_repition_mode_change_event::size(1),
-       encoded_event_mask.flow_specification_complete_event::size(1),
-       encoded_event_mask.inquiry_result_with_rssi_event::size(1),
-       encoded_event_mask.read_remote_extended_features_complete_event::size(1),
-       falsey::size(1),
-       falsey::size(1),
-       falsey::size(1),
-       falsey::size(1),
-       falsey::size(1),
-       falsey::size(1),
-       falsey::size(1),
-       falsey::size(1),
-       encoded_event_mask.synchronous_connection_complete_event::size(1),
-       encoded_event_mask.synchronous_connection_changed_event::size(1),
-       encoded_event_mask.sniff_subrating_event::size(1),
-       encoded_event_mask.extended_inquiry_result_event::size(1),
-       encoded_event_mask.encryption_key_refresh_complete_event::size(1),
-       encoded_event_mask.io_capability_request_event::size(1),
-       encoded_event_mask.io_capability_response_event::size(1),
-       encoded_event_mask.user_confirmation_request_event::size(1),
-       encoded_event_mask.user_passkey_request_event::size(1),
-       encoded_event_mask.remote_oob_data_request_event::size(1),
-       encoded_event_mask.simple_pairing_complete_event::size(1),
-       encoded_event_mask.link_supervision_timeout_changed_event::size(1),
-       encoded_event_mask.enhanced_flush_complete_event::size(1),
-       encoded_event_mask.user_passkey_notification_event::size(1),
-       encoded_event_mask.keypress_notification_event::size(1),
-       encoded_event_mask.remote_host_supported_features_notification_event::size(1),
-       encoded_event_mask.le_meta_event::size(1),
-       encoded_event_mask.reserved::bits
-     >>}
-  end
+  @fields [
+    :inquiry_complete_event,
+    :inquiry_result_event,
+    :connection_complete_event,
+    :connection_request_event,
+    :disconnection_complete_event,
+    :authentication_complete_event,
+    :remote_name_request_complete_event,
+    :encryption_change_event,
+    :change_connection_link_key_complete_event,
+    :mast_link_key_complete_event,
+    :read_remote_supported_features_complete_event,
+    :read_remote_version_information_complete_event,
+    :qos_setup_complete_event,
+    :hardware_error_event,
+    :flush_occurred_event,
+    :role_change_event,
+    :mode_change_event,
+    :return_link_keys_event,
+    :pin_code_request_event,
+    :link_key_request_event,
+    :link_key_notification_event,
+    :loopback_command_event,
+    :data_buffer_overflow_event,
+    :max_slots_change_event,
+    :read_clock_offset_complete_event,
+    :connection_packet_type_changed_event,
+    :qos_violation_event,
+    :page_scan_mode_change_event,
+    :page_scan_repition_mode_change_event,
+    :flow_specification_complete_event,
+    :inquiry_result_with_rssi_event,
+    :read_remote_extended_features_complete_event,
+    :synchronous_connection_complete_event,
+    :synchronous_connection_changed_event,
+    :sniff_subrating_event,
+    :extended_inquiry_result_event,
+    :encryption_key_refresh_complete_event,
+    :io_capability_request_event,
+    :io_capability_response_event,
+    :user_confirmation_request_event,
+    :user_passkey_request_event,
+    :remote_oob_data_request_event,
+    :simple_pairing_complete_event,
+    :link_supervision_timeout_changed_event,
+    :enhanced_flush_complete_event,
+    :user_passkey_notification_event,
+    :keypress_notification_event,
+    :remote_host_supported_features_notification_event,
+    :le_meta_event,
+    :reserved_map
+  ]
 
   @impl Command
   def decode(<<
+        # 0 - 12
         inquiry_complete_event::size(1),
         inquiry_result_event::size(1),
         connection_complete_event::size(1),
@@ -153,12 +131,15 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMask do
         read_remote_supported_features_complete_event::size(1),
         read_remote_version_information_complete_event::size(1),
         qos_setup_complete_event::size(1),
-        _::size(1),
-        _::size(1),
+        # 13 - 14
+        reserved_13_to_14::size(2),
+        # 15 - 17
         hardware_error_event::size(1),
-        flush_occurred_evnet::size(1),
+        flush_occurred_event::size(1),
         role_change_event::size(1),
-        _::size(1),
+        # 18
+        reserved_18::size(1),
+        # 19 - 34
         mode_change_event::size(1),
         return_link_keys_event::size(1),
         pin_code_request_event::size(1),
@@ -175,14 +156,9 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMask do
         flow_specification_complete_event::size(1),
         inquiry_result_with_rssi_event::size(1),
         read_remote_extended_features_complete_event::size(1),
-        _::size(1),
-        _::size(1),
-        _::size(1),
-        _::size(1),
-        _::size(1),
-        _::size(1),
-        _::size(1),
-        _::size(1),
+        # 35 - 42
+        reserved_35_to_42::size(8),
+        # 43 - 53
         synchronous_connection_complete_event::size(1),
         synchronous_connection_changed_event::size(1),
         sniff_subrating_event::size(1),
@@ -194,13 +170,20 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMask do
         user_passkey_request_event::size(1),
         remote_oob_data_request_event::size(1),
         simple_pairing_complete_event::size(1),
+        # 54
+        reserved_54::size(1),
+        # 55 - 56
         link_supervision_timeout_changed_event::size(1),
         enhanced_flush_complete_event::size(1),
+        # 57
+        reserved_57::size(1),
+        # 58 - 61
         user_passkey_notification_event::size(1),
         keypress_notification_event::size(1),
         remote_host_supported_features_notification_event::size(1),
         le_meta_event::size(1),
-        reserved::bits-size(4)
+        # 62 - 63
+        reserved_62_to_63::size(2)
       >>) do
     encoded_event_mask = %{
       inquiry_complete_event: inquiry_complete_event,
@@ -219,7 +202,7 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMask do
         read_remote_version_information_complete_event,
       qos_setup_complete_event: qos_setup_complete_event,
       hardware_error_event: hardware_error_event,
-      flush_occurred_evnet: flush_occurred_evnet,
+      flush_occurred_event: flush_occurred_event,
       role_change_event: role_change_event,
       mode_change_event: mode_change_event,
       return_link_keys_event: return_link_keys_event,
@@ -255,12 +238,19 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMask do
       remote_host_supported_features_notification_event:
         remote_host_supported_features_notification_event,
       le_meta_event: le_meta_event,
-      reserved: reserved
+      reserved_map: %{
+        (13..14) => reserved_13_to_14,
+        (18..18) => reserved_18,
+        (35..42) => reserved_35_to_42,
+        (54..54) => reserved_54,
+        (57..57) => reserved_57,
+        (62..63) => reserved_62_to_63
+      }
     }
 
     decoded_event_mask =
       Enum.into(encoded_event_mask, %{}, fn
-        {:reserved, reserved} -> {:reserved, reserved}
+        {:reserved_map, reserved} -> {:reserved_map, reserved}
         {key, 1} -> {key, true}
         {key, 0} -> {key, false}
       end)
@@ -274,8 +264,214 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMask do
   def decode_return_parameters(<<status>>), do: {:ok, %{status: status}}
 
   @impl Command
+  def encode(%{
+        event_mask:
+          %{
+            inquiry_complete_event: _,
+            inquiry_result_event: _,
+            connection_complete_event: _,
+            connection_request_event: _,
+            disconnection_complete_event: _,
+            authentication_complete_event: _,
+            remote_name_request_complete_event: _,
+            encryption_change_event: _,
+            change_connection_link_key_complete_event: _,
+            mast_link_key_complete_event: _,
+            read_remote_supported_features_complete_event: _,
+            read_remote_version_information_complete_event: _,
+            qos_setup_complete_event: _,
+            hardware_error_event: _,
+            flush_occurred_event: _,
+            role_change_event: _,
+            mode_change_event: _,
+            return_link_keys_event: _,
+            pin_code_request_event: _,
+            link_key_request_event: _,
+            link_key_notification_event: _,
+            loopback_command_event: _,
+            data_buffer_overflow_event: _,
+            max_slots_change_event: _,
+            read_clock_offset_complete_event: _,
+            connection_packet_type_changed_event: _,
+            qos_violation_event: _,
+            page_scan_mode_change_event: _,
+            page_scan_repition_mode_change_event: _,
+            flow_specification_complete_event: _,
+            inquiry_result_with_rssi_event: _,
+            read_remote_extended_features_complete_event: _,
+            synchronous_connection_complete_event: _,
+            synchronous_connection_changed_event: _,
+            sniff_subrating_event: _,
+            extended_inquiry_result_event: _,
+            encryption_key_refresh_complete_event: _,
+            io_capability_request_event: _,
+            io_capability_response_event: _,
+            user_confirmation_request_event: _,
+            user_passkey_request_event: _,
+            remote_oob_data_request_event: _,
+            simple_pairing_complete_event: _,
+            link_supervision_timeout_changed_event: _,
+            enhanced_flush_complete_event: _,
+            user_passkey_notification_event: _,
+            keypress_notification_event: _,
+            remote_host_supported_features_notification_event: _,
+            le_meta_event: _,
+            reserved_map: %{
+              (13..14) => reserved_13_to_14,
+              (18..18) => reserved_18,
+              (35..42) => reserved_35_to_42,
+              (54..54) => reserved_54,
+              (57..57) => reserved_57,
+              (62..63) => reserved_62_to_63
+            }
+          } = decoded_event_mask
+      }) do
+    encoded_event_mask =
+      Enum.into(decoded_event_mask, %{}, fn
+        {:reserved_map, reserved} -> {:reserved_map, reserved}
+        {key, true} -> {key, 1}
+        {key, false} -> {key, 0}
+      end)
+
+    encoded_set_event_mask = <<
+      # 0 - 12
+      encoded_event_mask.inquiry_complete_event::size(1),
+      encoded_event_mask.inquiry_result_event::size(1),
+      encoded_event_mask.connection_complete_event::size(1),
+      encoded_event_mask.connection_request_event::size(1),
+      encoded_event_mask.disconnection_complete_event::size(1),
+      encoded_event_mask.authentication_complete_event::size(1),
+      encoded_event_mask.remote_name_request_complete_event::size(1),
+      encoded_event_mask.encryption_change_event::size(1),
+      encoded_event_mask.change_connection_link_key_complete_event::size(1),
+      encoded_event_mask.mast_link_key_complete_event::size(1),
+      encoded_event_mask.read_remote_supported_features_complete_event::size(1),
+      encoded_event_mask.read_remote_version_information_complete_event::size(1),
+      encoded_event_mask.qos_setup_complete_event::size(1),
+      # 13 - 14
+      reserved_13_to_14::size(2),
+      # 15 - 17
+      encoded_event_mask.hardware_error_event::size(1),
+      encoded_event_mask.flush_occurred_event::size(1),
+      encoded_event_mask.role_change_event::size(1),
+      # 18
+      reserved_18::size(1),
+      # 19 - 34
+      encoded_event_mask.mode_change_event::size(1),
+      encoded_event_mask.return_link_keys_event::size(1),
+      encoded_event_mask.pin_code_request_event::size(1),
+      encoded_event_mask.link_key_request_event::size(1),
+      encoded_event_mask.link_key_notification_event::size(1),
+      encoded_event_mask.loopback_command_event::size(1),
+      encoded_event_mask.data_buffer_overflow_event::size(1),
+      encoded_event_mask.max_slots_change_event::size(1),
+      encoded_event_mask.read_clock_offset_complete_event::size(1),
+      encoded_event_mask.connection_packet_type_changed_event::size(1),
+      encoded_event_mask.qos_violation_event::size(1),
+      encoded_event_mask.page_scan_mode_change_event::size(1),
+      encoded_event_mask.page_scan_repition_mode_change_event::size(1),
+      encoded_event_mask.flow_specification_complete_event::size(1),
+      encoded_event_mask.inquiry_result_with_rssi_event::size(1),
+      encoded_event_mask.read_remote_extended_features_complete_event::size(1),
+      # 35 - 42
+      reserved_35_to_42::size(8),
+      # 43 - 53
+      encoded_event_mask.synchronous_connection_complete_event::size(1),
+      encoded_event_mask.synchronous_connection_changed_event::size(1),
+      encoded_event_mask.sniff_subrating_event::size(1),
+      encoded_event_mask.extended_inquiry_result_event::size(1),
+      encoded_event_mask.encryption_key_refresh_complete_event::size(1),
+      encoded_event_mask.io_capability_request_event::size(1),
+      encoded_event_mask.io_capability_response_event::size(1),
+      encoded_event_mask.user_confirmation_request_event::size(1),
+      encoded_event_mask.user_passkey_request_event::size(1),
+      encoded_event_mask.remote_oob_data_request_event::size(1),
+      encoded_event_mask.simple_pairing_complete_event::size(1),
+      # 54
+      reserved_54::size(1),
+      # 55 - 56
+      encoded_event_mask.link_supervision_timeout_changed_event::size(1),
+      encoded_event_mask.enhanced_flush_complete_event::size(1),
+      # 57
+      reserved_57::size(1),
+      # 58 - 61
+      encoded_event_mask.user_passkey_notification_event::size(1),
+      encoded_event_mask.keypress_notification_event::size(1),
+      encoded_event_mask.remote_host_supported_features_notification_event::size(1),
+      encoded_event_mask.le_meta_event::size(1),
+      # 62 - 63
+      reserved_62_to_63::size(2)
+    >>
+
+    {:ok, encoded_set_event_mask}
+  end
+
+  @impl Command
   def encode_return_parameters(%{status: status}), do: {:ok, <<status>>}
+
+  @doc """
+  Return a map ready for encoding.
+
+  Keys under `:event_mask` will be defaulted if not supplied.
+
+  ## Options
+
+  `encoded` - `boolean()`. `false`. Whether the return value is encoded or not.
+  `:default` - `boolean()`. `false`. The default value for unspecified fields under the
+    `:event_mask` field.
+  """
+  def new(%{event_mask: event_mask}, opts \\ []) do
+    default = Keyword.get(opts, :default, false)
+
+    with {:ok, mask} <- resolve_mask(event_mask, default) do
+      maybe_encode(%{event_mask: mask}, Keyword.get(opts, :encoded, false))
+    end
+  end
 
   @impl Command
   def ocf(), do: 0x01
+
+  defp maybe_encode(decoded_set_event_mask, true) do
+    encode(decoded_set_event_mask)
+  end
+
+  defp maybe_encode(decoded_set_event_mask, false), do: {:ok, decoded_set_event_mask}
+
+  defp resolve_mask(fields, default) do
+    truthy_reserved = %{
+      (13..14) => 3,
+      (18..18) => 1,
+      (35..42) => 255,
+      (54..54) => 1,
+      (57..57) => 1,
+      (62..63) => 3
+    }
+
+    falsey_reserved = %{
+      (13..14) => 0,
+      (18..18) => 0,
+      (35..42) => 0,
+      (54..54) => 0,
+      (57..57) => 0,
+      (62..63) => 0
+    }
+
+    reserved_default = if default, do: truthy_reserved, else: falsey_reserved
+
+    Enum.reduce_while(@fields, %{}, fn
+      :reserved_map, acc ->
+        case Map.fetch(fields, :reserved_map) do
+          {:ok, value} when is_integer(value) -> {:cont, Map.put(acc, :reserved_map, value)}
+          {:ok, _value} -> {:halt, {:error, :reserved_map}}
+          :error -> {:cont, Map.put(acc, :reserved_map, reserved_default)}
+        end
+
+      field, acc ->
+        {:cont, Map.put(acc, field, Map.get(fields, field, default))}
+    end)
+    |> case do
+      {:error, _} = e -> e
+      mask -> {:ok, mask}
+    end
+  end
 end

--- a/test/harald/hci/commands/controller_and_baseband/set_event_mask_test.exs
+++ b/test/harald/hci/commands/controller_and_baseband/set_event_mask_test.exs
@@ -1,196 +1,11 @@
 defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMaskTest do
   use ExUnit.Case, async: true
-  alias Harald.HCI.Commands.{Command, ControllerAndBaseband}
-  alias Harald.HCI.{Commands, Commands.ControllerAndBaseband.SetEventMask}
+  alias Harald.HCI.Commands.ControllerAndBaseband.SetEventMask
 
-  test "decode/1" do
-    decoded_event_mask = %{
-      inquiry_complete_event: 1,
-      inquiry_result_event: 1,
-      connection_complete_event: 1,
-      connection_request_event: 1,
-      disconnection_complete_event: 1,
-      authentication_complete_event: 1,
-      remote_name_request_complete_event: 1,
-      encryption_change_event: 1,
-      change_connection_link_key_complete_event: 1,
-      mast_link_key_complete_event: 1,
-      read_remote_supported_features_complete_event: 1,
-      read_remote_version_information_complete_event: 1,
-      qos_setup_complete_event: 1,
-      hardware_error_event: 1,
-      flush_occurred_evnet: 1,
-      role_change_event: 1,
-      mode_change_event: 1,
-      return_link_keys_event: 1,
-      pin_code_request_event: 1,
-      link_key_request_event: 1,
-      link_key_notification_event: 1,
-      loopback_command_event: 1,
-      data_buffer_overflow_event: 1,
-      max_slots_change_event: 1,
-      read_clock_offset_complete_event: 1,
-      connection_packet_type_changed_event: 1,
-      qos_violation_event: 1,
-      page_scan_mode_change_event: 1,
-      page_scan_repition_mode_change_event: 1,
-      flow_specification_complete_event: 1,
-      inquiry_result_with_rssi_event: 1,
-      read_remote_extended_features_complete_event: 1,
-      synchronous_connection_complete_event: 1,
-      synchronous_connection_changed_event: 1,
-      sniff_subrating_event: 1,
-      extended_inquiry_result_event: 1,
-      encryption_key_refresh_complete_event: 1,
-      io_capability_request_event: 1,
-      io_capability_response_event: 1,
-      user_confirmation_request_event: 1,
-      user_passkey_request_event: 1,
-      remote_oob_data_request_event: 1,
-      simple_pairing_complete_event: 1,
-      link_supervision_timeout_changed_event: 1,
-      enhanced_flush_complete_event: 1,
-      user_passkey_notification_event: 1,
-      keypress_notification_event: 1,
-      remote_host_supported_features_notification_event: 1,
-      le_meta_event: 1
-    }
+  setup :event_mask1
 
-    event_mask = <<
-      decoded_event_mask.inquiry_complete_event::size(1),
-      decoded_event_mask.inquiry_result_event::size(1),
-      decoded_event_mask.connection_complete_event::size(1),
-      decoded_event_mask.connection_request_event::size(1),
-      decoded_event_mask.disconnection_complete_event::size(1),
-      decoded_event_mask.authentication_complete_event::size(1),
-      decoded_event_mask.remote_name_request_complete_event::size(1),
-      decoded_event_mask.encryption_change_event::size(1),
-      decoded_event_mask.change_connection_link_key_complete_event::size(1),
-      decoded_event_mask.mast_link_key_complete_event::size(1),
-      decoded_event_mask.read_remote_supported_features_complete_event::size(1),
-      decoded_event_mask.read_remote_version_information_complete_event::size(1),
-      decoded_event_mask.qos_setup_complete_event::size(1),
-      0::size(1),
-      0::size(1),
-      decoded_event_mask.hardware_error_event::size(1),
-      decoded_event_mask.flush_occurred_evnet::size(1),
-      decoded_event_mask.role_change_event::size(1),
-      0::size(1),
-      decoded_event_mask.mode_change_event::size(1),
-      decoded_event_mask.return_link_keys_event::size(1),
-      decoded_event_mask.pin_code_request_event::size(1),
-      decoded_event_mask.link_key_request_event::size(1),
-      decoded_event_mask.link_key_notification_event::size(1),
-      decoded_event_mask.loopback_command_event::size(1),
-      decoded_event_mask.data_buffer_overflow_event::size(1),
-      decoded_event_mask.max_slots_change_event::size(1),
-      decoded_event_mask.read_clock_offset_complete_event::size(1),
-      decoded_event_mask.connection_packet_type_changed_event::size(1),
-      decoded_event_mask.qos_violation_event::size(1),
-      decoded_event_mask.page_scan_mode_change_event::size(1),
-      decoded_event_mask.page_scan_repition_mode_change_event::size(1),
-      decoded_event_mask.flow_specification_complete_event::size(1),
-      decoded_event_mask.inquiry_result_with_rssi_event::size(1),
-      decoded_event_mask.read_remote_extended_features_complete_event::size(1),
-      0::size(1),
-      0::size(1),
-      0::size(1),
-      0::size(1),
-      0::size(1),
-      0::size(1),
-      0::size(1),
-      0::size(1),
-      decoded_event_mask.synchronous_connection_complete_event::size(1),
-      decoded_event_mask.synchronous_connection_changed_event::size(1),
-      decoded_event_mask.sniff_subrating_event::size(1),
-      decoded_event_mask.extended_inquiry_result_event::size(1),
-      decoded_event_mask.encryption_key_refresh_complete_event::size(1),
-      decoded_event_mask.io_capability_request_event::size(1),
-      decoded_event_mask.io_capability_response_event::size(1),
-      decoded_event_mask.user_confirmation_request_event::size(1),
-      decoded_event_mask.user_passkey_request_event::size(1),
-      decoded_event_mask.remote_oob_data_request_event::size(1),
-      decoded_event_mask.simple_pairing_complete_event::size(1),
-      decoded_event_mask.link_supervision_timeout_changed_event::size(1),
-      decoded_event_mask.enhanced_flush_complete_event::size(1),
-      decoded_event_mask.user_passkey_notification_event::size(1),
-      decoded_event_mask.keypress_notification_event::size(1),
-      decoded_event_mask.remote_host_supported_features_notification_event::size(1),
-      decoded_event_mask.le_meta_event::size(1)
-    >>
-
-    reserved = 1
-
-    decoded_event_mask = %{
-      inquiry_complete_event: true,
-      inquiry_result_event: true,
-      connection_complete_event: true,
-      connection_request_event: true,
-      disconnection_complete_event: true,
-      authentication_complete_event: true,
-      remote_name_request_complete_event: true,
-      encryption_change_event: true,
-      change_connection_link_key_complete_event: true,
-      mast_link_key_complete_event: true,
-      read_remote_supported_features_complete_event: true,
-      read_remote_version_information_complete_event: true,
-      qos_setup_complete_event: true,
-      hardware_error_event: true,
-      flush_occurred_evnet: true,
-      role_change_event: true,
-      mode_change_event: true,
-      return_link_keys_event: true,
-      pin_code_request_event: true,
-      link_key_request_event: true,
-      link_key_notification_event: true,
-      loopback_command_event: true,
-      data_buffer_overflow_event: true,
-      max_slots_change_event: true,
-      read_clock_offset_complete_event: true,
-      connection_packet_type_changed_event: true,
-      qos_violation_event: true,
-      page_scan_mode_change_event: true,
-      page_scan_repition_mode_change_event: true,
-      flow_specification_complete_event: true,
-      inquiry_result_with_rssi_event: true,
-      read_remote_extended_features_complete_event: true,
-      synchronous_connection_complete_event: true,
-      synchronous_connection_changed_event: true,
-      sniff_subrating_event: true,
-      extended_inquiry_result_event: true,
-      encryption_key_refresh_complete_event: true,
-      io_capability_request_event: true,
-      io_capability_response_event: true,
-      user_confirmation_request_event: true,
-      user_passkey_request_event: true,
-      remote_oob_data_request_event: true,
-      simple_pairing_complete_event: true,
-      link_supervision_timeout_changed_event: true,
-      enhanced_flush_complete_event: true,
-      user_passkey_notification_event: true,
-      keypress_notification_event: true,
-      remote_host_supported_features_notification_event: true,
-      le_meta_event: true,
-      reserved: <<reserved::size(4)>>
-    }
-
-    parameters = <<event_mask::bits, 1::size(4)>>
-    parameters_length = byte_size(parameters)
-    expected_bin = <<1, 1, 12, parameters_length, parameters::bits>>
-
-    expected_command = %Command{
-      command_op_code: %{
-        ocf: 0x01,
-        ocf_module: SetEventMask,
-        ogf: 0x03,
-        ogf_module: ControllerAndBaseband
-      },
-      parameters: %{
-        event_mask: decoded_event_mask
-      }
-    }
-
-    assert {:ok, expected_command} == Commands.decode(expected_bin)
+  test "decode/1", context do
+    assert {:ok, context.event_mask1.decoded} == SetEventMask.decode(context.event_mask1.encoded)
   end
 
   test "decode_return_parameters/1" do
@@ -202,8 +17,39 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMaskTest do
              SetEventMask.decode_return_parameters(return_parameters)
   end
 
-  test "encode/1" do
-    decoded_event_mask = %{
+  test "encode/1", context do
+    assert {:ok, context.event_mask1.encoded} == SetEventMask.encode(context.event_mask1.decoded)
+  end
+
+  test "encode_return_parameters/1" do
+    status = 1
+    encoded_return_parameters = <<status>>
+    decoded_return_parameters = %{status: status}
+
+    assert {:ok, encoded_return_parameters} ==
+             SetEventMask.encode_return_parameters(decoded_return_parameters)
+  end
+
+  describe "new/2" do
+    test "default", context do
+      assert {:ok, context.event_mask1.decoded} ==
+               SetEventMask.new(%{event_mask: %{}}, default: true)
+    end
+  end
+
+  test "ocf/0" do
+    assert 0x01 == SetEventMask.ocf()
+  end
+
+  defp event_mask1(context) do
+    reserved_13_to_14 = 3
+    reserved_18 = 1
+    reserved_35_to_42 = 255
+    reserved_54 = 1
+    reserved_57 = 1
+    reserved_62_to_63 = 3
+
+    event_mask_values = %{
       inquiry_complete_event: 1,
       inquiry_result_event: 1,
       connection_complete_event: 1,
@@ -218,7 +64,7 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMaskTest do
       read_remote_version_information_complete_event: 1,
       qos_setup_complete_event: 1,
       hardware_error_event: 1,
-      flush_occurred_evnet: 1,
+      flush_occurred_event: 1,
       role_change_event: 1,
       mode_change_event: 1,
       return_link_keys_event: 1,
@@ -253,150 +99,94 @@ defmodule Harald.HCI.Commands.ControllerAndBaseband.SetEventMaskTest do
       keypress_notification_event: 1,
       remote_host_supported_features_notification_event: 1,
       le_meta_event: 1,
-      reserved: <<1::size(4)>>
+      reserved_map: %{
+        (13..14) => reserved_13_to_14,
+        (18..18) => reserved_18,
+        (35..42) => reserved_35_to_42,
+        (54..54) => reserved_54,
+        (57..57) => reserved_57,
+        (62..63) => reserved_62_to_63
+      }
     }
 
-    falsey = 0
-
-    event_mask = <<
-      decoded_event_mask.inquiry_complete_event::size(1),
-      decoded_event_mask.inquiry_result_event::size(1),
-      decoded_event_mask.connection_complete_event::size(1),
-      decoded_event_mask.connection_request_event::size(1),
-      decoded_event_mask.disconnection_complete_event::size(1),
-      decoded_event_mask.authentication_complete_event::size(1),
-      decoded_event_mask.remote_name_request_complete_event::size(1),
-      decoded_event_mask.encryption_change_event::size(1),
-      decoded_event_mask.change_connection_link_key_complete_event::size(1),
-      decoded_event_mask.mast_link_key_complete_event::size(1),
-      decoded_event_mask.read_remote_supported_features_complete_event::size(1),
-      decoded_event_mask.read_remote_version_information_complete_event::size(1),
-      decoded_event_mask.qos_setup_complete_event::size(1),
-      falsey::size(1),
-      falsey::size(1),
-      decoded_event_mask.hardware_error_event::size(1),
-      decoded_event_mask.flush_occurred_evnet::size(1),
-      decoded_event_mask.role_change_event::size(1),
-      falsey::size(1),
-      decoded_event_mask.mode_change_event::size(1),
-      decoded_event_mask.return_link_keys_event::size(1),
-      decoded_event_mask.pin_code_request_event::size(1),
-      decoded_event_mask.link_key_request_event::size(1),
-      decoded_event_mask.link_key_notification_event::size(1),
-      decoded_event_mask.loopback_command_event::size(1),
-      decoded_event_mask.data_buffer_overflow_event::size(1),
-      decoded_event_mask.max_slots_change_event::size(1),
-      decoded_event_mask.read_clock_offset_complete_event::size(1),
-      decoded_event_mask.connection_packet_type_changed_event::size(1),
-      decoded_event_mask.qos_violation_event::size(1),
-      decoded_event_mask.page_scan_mode_change_event::size(1),
-      decoded_event_mask.page_scan_repition_mode_change_event::size(1),
-      decoded_event_mask.flow_specification_complete_event::size(1),
-      decoded_event_mask.inquiry_result_with_rssi_event::size(1),
-      decoded_event_mask.read_remote_extended_features_complete_event::size(1),
-      falsey::size(1),
-      falsey::size(1),
-      falsey::size(1),
-      falsey::size(1),
-      falsey::size(1),
-      falsey::size(1),
-      falsey::size(1),
-      falsey::size(1),
-      decoded_event_mask.synchronous_connection_complete_event::size(1),
-      decoded_event_mask.synchronous_connection_changed_event::size(1),
-      decoded_event_mask.sniff_subrating_event::size(1),
-      decoded_event_mask.extended_inquiry_result_event::size(1),
-      decoded_event_mask.encryption_key_refresh_complete_event::size(1),
-      decoded_event_mask.io_capability_request_event::size(1),
-      decoded_event_mask.io_capability_response_event::size(1),
-      decoded_event_mask.user_confirmation_request_event::size(1),
-      decoded_event_mask.user_passkey_request_event::size(1),
-      decoded_event_mask.remote_oob_data_request_event::size(1),
-      decoded_event_mask.simple_pairing_complete_event::size(1),
-      decoded_event_mask.link_supervision_timeout_changed_event::size(1),
-      decoded_event_mask.enhanced_flush_complete_event::size(1),
-      decoded_event_mask.user_passkey_notification_event::size(1),
-      decoded_event_mask.keypress_notification_event::size(1),
-      decoded_event_mask.remote_host_supported_features_notification_event::size(1),
-      decoded_event_mask.le_meta_event::size(1)
+    encoded = <<
+      # 0 - 12
+      event_mask_values.inquiry_complete_event::size(1),
+      event_mask_values.inquiry_result_event::size(1),
+      event_mask_values.connection_complete_event::size(1),
+      event_mask_values.connection_request_event::size(1),
+      event_mask_values.disconnection_complete_event::size(1),
+      event_mask_values.authentication_complete_event::size(1),
+      event_mask_values.remote_name_request_complete_event::size(1),
+      event_mask_values.encryption_change_event::size(1),
+      event_mask_values.change_connection_link_key_complete_event::size(1),
+      event_mask_values.mast_link_key_complete_event::size(1),
+      event_mask_values.read_remote_supported_features_complete_event::size(1),
+      event_mask_values.read_remote_version_information_complete_event::size(1),
+      event_mask_values.qos_setup_complete_event::size(1),
+      # 13 - 14
+      reserved_13_to_14::size(2),
+      # 15 - 17
+      event_mask_values.hardware_error_event::size(1),
+      event_mask_values.flush_occurred_event::size(1),
+      event_mask_values.role_change_event::size(1),
+      # 18
+      reserved_18::size(1),
+      # 19 - 34
+      event_mask_values.mode_change_event::size(1),
+      event_mask_values.return_link_keys_event::size(1),
+      event_mask_values.pin_code_request_event::size(1),
+      event_mask_values.link_key_request_event::size(1),
+      event_mask_values.link_key_notification_event::size(1),
+      event_mask_values.loopback_command_event::size(1),
+      event_mask_values.data_buffer_overflow_event::size(1),
+      event_mask_values.max_slots_change_event::size(1),
+      event_mask_values.read_clock_offset_complete_event::size(1),
+      event_mask_values.connection_packet_type_changed_event::size(1),
+      event_mask_values.qos_violation_event::size(1),
+      event_mask_values.page_scan_mode_change_event::size(1),
+      event_mask_values.page_scan_repition_mode_change_event::size(1),
+      event_mask_values.flow_specification_complete_event::size(1),
+      event_mask_values.inquiry_result_with_rssi_event::size(1),
+      event_mask_values.read_remote_extended_features_complete_event::size(1),
+      # 35 - 42
+      reserved_35_to_42::size(8),
+      # 43 - 53
+      event_mask_values.synchronous_connection_complete_event::size(1),
+      event_mask_values.synchronous_connection_changed_event::size(1),
+      event_mask_values.sniff_subrating_event::size(1),
+      event_mask_values.extended_inquiry_result_event::size(1),
+      event_mask_values.encryption_key_refresh_complete_event::size(1),
+      event_mask_values.io_capability_request_event::size(1),
+      event_mask_values.io_capability_response_event::size(1),
+      event_mask_values.user_confirmation_request_event::size(1),
+      event_mask_values.user_passkey_request_event::size(1),
+      event_mask_values.remote_oob_data_request_event::size(1),
+      event_mask_values.simple_pairing_complete_event::size(1),
+      # 54
+      reserved_54::size(1),
+      # 55 - 56
+      event_mask_values.link_supervision_timeout_changed_event::size(1),
+      event_mask_values.enhanced_flush_complete_event::size(1),
+      # 57
+      reserved_57::size(1),
+      # 58 - 61
+      event_mask_values.user_passkey_notification_event::size(1),
+      event_mask_values.keypress_notification_event::size(1),
+      event_mask_values.remote_host_supported_features_notification_event::size(1),
+      event_mask_values.le_meta_event::size(1),
+      # 62 - 63
+      reserved_62_to_63::size(2)
     >>
 
-    reserved = 1
+    event_mask_decoded_values =
+      Enum.into(event_mask_values, %{}, fn
+        {:reserved_map, reserved} -> {:reserved_map, reserved}
+        {key, 1} -> {key, true}
+        {key, 0} -> {key, false}
+      end)
 
-    decoded_event_mask = %{
-      inquiry_complete_event: true,
-      inquiry_result_event: true,
-      connection_complete_event: true,
-      connection_request_event: true,
-      disconnection_complete_event: true,
-      authentication_complete_event: true,
-      remote_name_request_complete_event: true,
-      encryption_change_event: true,
-      change_connection_link_key_complete_event: true,
-      mast_link_key_complete_event: true,
-      read_remote_supported_features_complete_event: true,
-      read_remote_version_information_complete_event: true,
-      qos_setup_complete_event: true,
-      hardware_error_event: true,
-      flush_occurred_evnet: true,
-      role_change_event: true,
-      mode_change_event: true,
-      return_link_keys_event: true,
-      pin_code_request_event: true,
-      link_key_request_event: true,
-      link_key_notification_event: true,
-      loopback_command_event: true,
-      data_buffer_overflow_event: true,
-      max_slots_change_event: true,
-      read_clock_offset_complete_event: true,
-      connection_packet_type_changed_event: true,
-      qos_violation_event: true,
-      page_scan_mode_change_event: true,
-      page_scan_repition_mode_change_event: true,
-      flow_specification_complete_event: true,
-      inquiry_result_with_rssi_event: true,
-      read_remote_extended_features_complete_event: true,
-      synchronous_connection_complete_event: true,
-      synchronous_connection_changed_event: true,
-      sniff_subrating_event: true,
-      extended_inquiry_result_event: true,
-      encryption_key_refresh_complete_event: true,
-      io_capability_request_event: true,
-      io_capability_response_event: true,
-      user_confirmation_request_event: true,
-      user_passkey_request_event: true,
-      remote_oob_data_request_event: true,
-      simple_pairing_complete_event: true,
-      link_supervision_timeout_changed_event: true,
-      enhanced_flush_complete_event: true,
-      user_passkey_notification_event: true,
-      keypress_notification_event: true,
-      remote_host_supported_features_notification_event: true,
-      le_meta_event: true,
-      reserved: <<reserved::size(4)>>
-    }
-
-    parameters = <<event_mask::bits, 1::size(4)>>
-    parameters_length = byte_size(parameters)
-    expected_bin = <<1, 1, 12, parameters_length, parameters::binary>>
-    expected_size = byte_size(expected_bin)
-    parameters = %{event_mask: decoded_event_mask}
-
-    assert {:ok, actual_bin} = Commands.encode(ControllerAndBaseband, SetEventMask, parameters)
-    assert expected_size == byte_size(actual_bin)
-    assert expected_bin == actual_bin
-  end
-
-  test "encode_return_parameters/1" do
-    status = 1
-    encoded_return_parameters = <<status>>
-    decoded_return_parameters = %{status: status}
-
-    assert {:ok, encoded_return_parameters} ==
-             SetEventMask.encode_return_parameters(decoded_return_parameters)
-  end
-
-  test "ocf/0" do
-    assert 0x01 == SetEventMask.ocf()
+    decoded = %{event_mask: event_mask_decoded_values}
+    Map.put(context, :event_mask1, %{encoded: encoded, decoded: decoded})
   end
 end


### PR DESCRIPTION
Why
---

- The event_mask field has so many sub-fields that it is cumbersome to
  work with, particularly when you only care about a few sub-fields.

How
---

- Add SetEventMask.new/{1,2}
  - Can return an encoded or decoded value.
  - Sub-fields of event_mask are defaulted to true or false as dictated
    by the caller.

---

**Before merging:**

This work is branched off of unmerged work.

- Merge #92.
- Rebase this branch off main.
- Update merge target to main.